### PR TITLE
Fixing bazel build to have correct parameters for linking m4 with clang.

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -44,6 +44,7 @@ configure_make(
     ],
     configure_env_vars = {
         "AR": "ar_wrapper",
+	"LDFLAGS": "-stdlib=libc++ -B lld -lc++ --rtlib=compiler-rt --unwindlib=libunwind",
     },
     configure_options = [
         "--disable-nls",


### PR DESCRIPTION
Adds LDFLAGS to the m4 build as bazel was not properly propagating them.

Should now be possible to build using:

CC=clang CXX=clang++ CFLAGS="-stdlib=libc++" LDFLAGS="-stdlib=libc++ -B lld -lc++ --rtlib=compiler-rt --unwindlib=libunwind" bazel build //... --copt="-stdlib=libc++" --copt="-Wno-error=unused-command-line-argument" --linkopt="--rtlib=compiler-rt" --linkopt="--unwindlib=libunwind" --linkopt="-stdlib=libc++" --linkopt="-lc++"