### PR TITLE
Further build changes to support compiling with asan for non-build tools

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -44,7 +44,9 @@ configure_make(
     ],
     configure_env_vars = {
         "AR": "ar_wrapper",
-	"LDFLAGS": "-stdlib=libc++ -B lld -lc++ --rtlib=compiler-rt --unwindlib=libunwind",
+        "CFLAGS":"-fno-sanitize=address",
+        "CXXFLAGS":"-fno-sanitize=address",
+        "LDFLAGS": "-stdlib=libc++ -B lld -lc++ --rtlib=compiler-rt --unwindlib=libunwind -fno-sanitize=address",
     },
     configure_options = [
         "--disable-nls",
@@ -68,6 +70,9 @@ configure_make(
     configure_env_vars = {
         "M4": "$$EXT_BUILD_DEPS$$/m4/bin/m4",
         "CC_FOR_BUILD": "$$CC$$",
+        "CFLAGS":"-fno-sanitize=address",
+        "CXXFLAGS":"-fno-sanitize=address",
+        "LDFLAGS": "-stdlib=libc++ -B lld -lc++ --rtlib=compiler-rt --unwindlib=libunwind -fno-sanitize=address",
         "AR": "ar_wrapper",
     },
     lib_source = "@bison//:all",
@@ -93,6 +98,9 @@ configure_make(
     configure_env_vars = {
         "M4": "$$EXT_BUILD_DEPS$$/m4/bin/m4",
         "AR": "ar_wrapper",
+        "CFLAGS":"-fno-sanitize=address",
+        "CXXFLAGS":"-fno-sanitize=address",
+        "LDFLAGS": "-stdlib=libc++ -B lld -lc++ --rtlib=compiler-rt --unwindlib=libunwind -fno-sanitize=address",
     },
     lib_source = "@flex//:all",
     tools_deps = [":ar_wrapper"],


### PR DESCRIPTION
Adds -fno-sanitize=address to the build for various build-time dependencies.

This is a workaround to a tricky problem--we want to compile things with -fsanitize=address (and other sanitizers, eventually).  However, the versions of m4/bison/flex we've depended on to generate code don't seem to play super nicely with those sanitizers.  Good news is that since they run at build time just to generate code, there's no downside to simply building them in whatever way we please.

This works around this by selectively turning off ASAN for these targets.  Longer term, we probably want to standardize these behaviors and make them somewhat dependent on the compiler and existing copts/cxxopts passed into the larger build, but for now this workaround will let us compile ZetaSQL with ASAN and clang.