### PR TITLE
Simple Evaluator Fuzzer

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -20,3 +20,8 @@
 # widely accepted by compilers. This may lead to strange behavior or compiler
 # errors in earlier compilers.
 build --cxxopt="-std=c++1z"
+
+# Set to mute complaint for undefined environment variable 
+# when a normal build is performed. LIB_FUZZING_ENGINE is used primarily for
+# specifying fuzzing engine from OSS-Fuzz project
+common --define LIB_FUZZING_ENGINE=''

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+bazel-out
+bazel-bin
+bazel-testlogs
+bazel-zetasql-fuzzing
+

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -44,9 +44,9 @@ configure_make(
     ],
     configure_env_vars = {
         "AR": "ar_wrapper",
-        "CFLAGS":"-fno-sanitize=address",
-        "CXXFLAGS":"-fno-sanitize=address",
-        "LDFLAGS": "-stdlib=libc++ -B lld -lc++ --rtlib=compiler-rt --unwindlib=libunwind -fno-sanitize=address",
+        "CFLAGS":"-fno-sanitize=all",
+        "CXXFLAGS":"-fno-sanitize=all",
+        "LDFLAGS": "-stdlib=libc++ -B lld -lc++ --rtlib=compiler-rt --unwindlib=libunwind -fno-sanitize=all",
     },
     configure_options = [
         "--disable-nls",
@@ -70,9 +70,9 @@ configure_make(
     configure_env_vars = {
         "M4": "$$EXT_BUILD_DEPS$$/m4/bin/m4",
         "CC_FOR_BUILD": "$$CC$$",
-        "CFLAGS":"-fno-sanitize=address",
-        "CXXFLAGS":"-fno-sanitize=address",
-        "LDFLAGS": "-stdlib=libc++ -B lld -lc++ --rtlib=compiler-rt --unwindlib=libunwind -fno-sanitize=address",
+        "CFLAGS":"-fno-sanitize=all",
+        "CXXFLAGS":"-fno-sanitize=all",
+        "LDFLAGS": "-stdlib=libc++ -B lld -lc++ --rtlib=compiler-rt --unwindlib=libunwind -fno-sanitize=all",
         "AR": "ar_wrapper",
     },
     lib_source = "@bison//:all",
@@ -98,9 +98,9 @@ configure_make(
     configure_env_vars = {
         "M4": "$$EXT_BUILD_DEPS$$/m4/bin/m4",
         "AR": "ar_wrapper",
-        "CFLAGS":"-fno-sanitize=address",
-        "CXXFLAGS":"-fno-sanitize=address",
-        "LDFLAGS": "-stdlib=libc++ -B lld -lc++ --rtlib=compiler-rt --unwindlib=libunwind -fno-sanitize=address",
+        "CFLAGS":"-fno-sanitize=all",
+        "CXXFLAGS":"-fno-sanitize=all",
+        "LDFLAGS": "-stdlib=libc++ -B lld -lc++ --rtlib=compiler-rt --unwindlib=libunwind -fno-sanitize=all",
     },
     lib_source = "@flex//:all",
     tools_deps = [":ar_wrapper"],

--- a/zetasql/fuzzing/BUILD
+++ b/zetasql/fuzzing/BUILD
@@ -1,0 +1,35 @@
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This directory contains code to perform fuzz testing on ZetaSQL; its logic
+# is not part of the real ZetaSQL library.
+
+package(
+    default_visibility = ["//:__subpackages__"],
+)
+
+cc_binary(
+    name = "simple_evaluator_fuzzer",
+    srcs = [
+        "simple_evaluator_fuzzer.cc",
+    ],
+    linkopts = [ "$(LIB_FUZZING_ENGINE)" ],
+    linkstatic = 1,
+    testonly = 1,
+    deps = [
+        "//zetasql/public:evaluator",
+    ],
+)

--- a/zetasql/fuzzing/simple_evaluator_fuzzer.cc
+++ b/zetasql/fuzzing/simple_evaluator_fuzzer.cc
@@ -1,0 +1,56 @@
+//
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include <cstdint>
+#include <cstddef>
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+
+#include "zetasql/public/evaluator.h"
+
+#ifdef __OSS_FUZZ__
+#define OVERWRITE 1
+
+bool DoOssFuzzInit() {
+  namespace fs = std::filesystem;
+  fs::path originDir;
+  try {
+    originDir = fs::canonical(fs::read_symlink("/proc/self/exe")).parent_path();
+  } catch (const std::exception& e) {
+    return false;
+  }
+  fs::path tzdataDir = originDir / "data/zoneinfo/";
+  if (setenv("TZDIR", tzdataDir.c_str(), OVERWRITE)) {
+    return false;
+  }
+  return true;
+}
+#endif
+
+// Fuzz target interface implementaion. This function takes of length *Size* 
+// an array of randomly generated input of uint8_t, and tries to interpret it
+// as a SQL expression.
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+  #ifdef __OSS_FUZZ__
+    static bool Initialized = DoOssFuzzInit();
+    if (!Initialized) { std::abort(); }
+  #endif
+
+  const std::string sqlExp(reinterpret_cast<const char*>(Data), Size);
+  zetasql::PreparedExpression expression(sqlExp);
+  return 0;
+}


### PR DESCRIPTION
This PR includes a new bazel build config to integrating libFuzzer fuzzing engine to ZetaSQL, and a new fuzz target that takes raw fuzzing input, interpret as ZetaSQL expression and invokes ZetaSQL expression evaluator. The existing code should perform operations described with libFuzzer but no other fuzzing engine.

To test this fuzzer, do `bazel run --config=fuzzer //zetasql/fuzzing:simple_evaluator_fuzzer`

To integrate into OSS-Fuzz, this PR still needs to

- [x] Parameterize fuzzing engine in compiler/linker flags so arbitrary engine can be used.