### PR TITLE
Unifiy Fuzzer Target for ease of "Bazel query"

### DIFF
--- a/bazel/fuzzing.bzl
+++ b/bazel/fuzzing.bzl
@@ -1,0 +1,54 @@
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
+def cc_fuzzer(name, additional_linkopts = [], additional_deps = [], **kwargs):
+    """Define a fuzzer test target that is used with OSS-Fuzz project. 
+    
+    See https://google.github.io/oss-fuzz/advanced-topics/ideal-integration/#fuzz-target
+
+    Args:
+        additional_linkopts: linkopts to specify in addition to those for an OSS-Fuzz fuzzer
+        additional_deps: deps to specify in addition to those for an OSS-Fuzz fuzzer
+    """
+
+    cc_binary(
+        name = name,
+        linkopts = [ "$(LIB_FUZZING_ENGINE)" ] + additional_linkopts,
+        linkstatic = 1,
+        testonly = 1,
+        deps = [ "//zetasql/fuzzing:oss_fuzz" ] + additional_deps,
+        tags = [ "fuzzer" ],
+        **kwargs,
+    )
+
+def cc_proto_fuzzer(name, additional_linkopts = [], additional_deps = [], **kwargs):
+    """Define a fuzzer test target that is used with OSS-Fuzz project and libprotobuf-mutator
+
+    See https://google.github.io/oss-fuzz/advanced-topics/ideal-integration/#fuzz-target
+
+    Args:
+        additional_linkopts: linkopts to specify in addition to those for an OSS-Fuzz fuzzer w/ libprotobuf-mutator dependency
+        additional_deps: deps to specify in addition to those for an OSS-Fuzz fuzzer w/ libprotobuf-mutator dependency
+    """
+
+    cc_fuzzer(
+        name,
+        additional_linkopts = additional_linkopts,
+        additional_deps = [ "@libprotobuf_mutator//:libprotobuf_mutator" ] + additional_deps,
+        **kwargs,
+    )

--- a/zetasql/fuzzing/BUILD
+++ b/zetasql/fuzzing/BUILD
@@ -18,52 +18,31 @@
 # is not part of the real ZetaSQL library.
 
 load("@rules_proto//proto:defs.bzl", "proto_library")
+load("//bazel:fuzzing.bzl", "cc_fuzzer", "cc_proto_fuzzer")
 
 package(
     default_visibility = ["//:__subpackages__"],
 )
 
-cc_binary(
-    name = "simple_evaluator_fuzzer",
-    srcs = [
-        "simple_evaluator_fuzzer.cc",
-        "oss_fuzz.h",
-    ],
-    linkopts = [ "$(LIB_FUZZING_ENGINE)" ],
-    linkstatic = 1,
-    testonly = 1,
-    deps = [
-        "//zetasql/public:evaluator",
-    ],
+cc_library(
+    name = "oss_fuzz",
+    hdrs = [ "oss_fuzz.h", ]
 )
 
-cc_binary(
+cc_fuzzer(
+    name = "simple_evaluator_fuzzer",
+    srcs = [ "simple_evaluator_fuzzer.cc", ],
+    additional_deps = [ "//zetasql/public:evaluator", ],
+)
+
+cc_proto_fuzzer(
     name = "zetasql_expression_fuzzer",
-    srcs = [
-        "zetasql_expression_fuzzer.cc",
-        "oss_fuzz.h",
-    ],
-    linkopts = [ "$(LIB_FUZZING_ENGINE)" ],
-    linkstatic = 1,
-    testonly = 1,
-    deps = [
+    srcs = [ "zetasql_expression_fuzzer.cc", ],
+    additional_deps = [
         "//zetasql/public:evaluator",
         ":zetasql_expression_cc_proto",
         ":zetasql_expression_proto_to_string",
-        "@libprotobuf_mutator//:libprotobuf_mutator",
     ],
-)
-
-cc_library(
-    name = "zetasql_expression_proto_to_string",
-    srcs = [
-        "zetasql_expression_proto_to_string.cc",
-    ],
-    hdrs = [ "zetasql_expression_proto_to_string.h" ],
-    deps = [
-        ":zetasql_expression_cc_proto",
-        "@com_google_absl//absl/strings",
-    ]
 )
 
 cc_test(
@@ -74,6 +53,16 @@ cc_test(
         ":zetasql_expression_proto_to_string",
         "@com_google_googletest//:gtest_main",
     ],
+)
+
+cc_library(
+    name = "zetasql_expression_proto_to_string",
+    srcs = [ "zetasql_expression_proto_to_string.cc", ],
+    hdrs = [ "zetasql_expression_proto_to_string.h" ],
+    deps = [
+        ":zetasql_expression_cc_proto",
+        "@com_google_absl//absl/strings",
+    ]
 )
 
 cc_proto_library(


### PR DESCRIPTION
This PR introduces an refactored interface that defines cc_binary and common linktopts/deps for fuzzers, as well as a tag that can work easily with `bazel query`, which is proposed in https://github.com/google/oss-fuzz/pull/4095