### PR TITLE
Fuzzing PreparedExpression#Execute and #ExecuteWithPositionalParams with columns and parameters

### DIFF
--- a/zetasql/fuzzing/BUILD
+++ b/zetasql/fuzzing/BUILD
@@ -68,3 +68,14 @@ cc_proto_fuzzer(
         "//zetasql/fuzzing/protobuf:argument_extractors",
     ]
 )
+
+cc_proto_fuzzer(
+    name = "positional_param_expression_fuzzer",
+    srcs = [ "positional_param_expression_fuzzer.cc" ],
+    additional_deps = [
+        ":fuzzer_macro",
+        "//zetasql/fuzzing/component:prepared_expression_positional_target",
+        "//zetasql/fuzzing/protobuf:zetasql_expression_cc_proto",
+        "//zetasql/fuzzing/protobuf:argument_extractors",
+    ]
+)

--- a/zetasql/fuzzing/component/BUILD
+++ b/zetasql/fuzzing/component/BUILD
@@ -30,7 +30,7 @@ cc_library(
     deps = [
         "//zetasql/base:logging",
         "//zetasql/base:statusor",
-        "//zetasql/public:evaluator"
+        "//zetasql/public:evaluator_base"
     ]
 )
 

--- a/zetasql/fuzzing/component/BUILD
+++ b/zetasql/fuzzing/component/BUILD
@@ -64,6 +64,17 @@ cc_library(
 )
 
 cc_library(
+    name = "prepared_expression_positional_target",
+    srcs = [ "fuzz_targets/prepared_expression_positional_target.cc" ],
+    hdrs = [ "fuzz_targets/prepared_expression_positional_target.h"],
+    deps = [
+        ":fuzz_target",
+        ":parameter_value_argument",
+        "//zetasql/public:evaluator",
+    ]
+)
+
+cc_library(
     name = "runner",
     srcs = [],
     hdrs = [ "runner.h" ],

--- a/zetasql/fuzzing/component/BUILD
+++ b/zetasql/fuzzing/component/BUILD
@@ -34,6 +34,14 @@ cc_library(
     ]
 )
 
+cc_library(
+    name = "parameter_value_argument",
+    hdrs = [ "arguments/parameter_value_argument.h" ],
+    deps = [
+        ":fuzz_target",
+    ]
+)
+
 cc_test(
     name = "argument_test",
     srcs = [ "arguments/argument_test.cc" ],
@@ -50,6 +58,7 @@ cc_library(
     hdrs = [ "fuzz_targets/prepared_expression_target.h"],
     deps = [
         ":fuzz_target",
+        ":parameter_value_argument",
         "//zetasql/public:evaluator",
     ]
 )

--- a/zetasql/fuzzing/component/BUILD
+++ b/zetasql/fuzzing/component/BUILD
@@ -26,9 +26,12 @@ cc_library(
     hdrs = [ 
         "fuzz_targets/fuzz_target.h",
         "arguments/argument.h",
-        "//zetasql/base:logging",
-        "//zetasql/base:statusor"
     ],
+    deps = [
+        "//zetasql/base:logging",
+        "//zetasql/base:statusor",
+        "//zetasql/public:evaluator"
+    ]
 )
 
 cc_test(

--- a/zetasql/fuzzing/component/arguments/argument.h
+++ b/zetasql/fuzzing/component/arguments/argument.h
@@ -22,12 +22,13 @@
 
 #include "zetasql/base/statusor.h"
 #include "zetasql/fuzzing/component/fuzz_targets/fuzz_target.h"
-#include "zetasql/public/evaluator_base.h"
 
 namespace zetasql_fuzzer {
 
 class Argument {
  public:
+  virtual ~Argument() = default;
+
   // Accepts a FuzzTarget as a Visitor to this Argument
   virtual void Accept(zetasql_fuzzer::FuzzTarget& function) = 0;
 };
@@ -66,36 +67,6 @@ class SQLStringArg : public TypedArg<std::string> {
   void Accept(zetasql_fuzzer::FuzzTarget& function) override {
     function.Visit(*this);
   }
-};
-
-class ParameterValueMapArg : public TypedArg<zetasql::ParameterValueMap> {
- public:
-  enum As { COLUMNS, PARAMETERS };
-
-  ParameterValueMapArg() = delete;
-  ParameterValueMapArg(const ParameterValueMapArg&) = delete;
-  ParameterValueMapArg& operator=(const ParameterValueMapArg&) = delete;
-
-  ParameterValueMapArg(ParameterValueMapArg&&) = default;
-  ParameterValueMapArg& operator=(ParameterValueMapArg&&) = default;
-
-  ParameterValueMapArg(const zetasql::ParameterValueMap& value, As intent)
-      : TypedArg(value), intent_(intent) {}
-  ParameterValueMapArg(zetasql::ParameterValueMap&& value, As intent)
-      : TypedArg(value), intent_(intent) {}
-  ParameterValueMapArg(std::unique_ptr<zetasql::ParameterValueMap> pointer, As intent)
-      : TypedArg(std::move(pointer)), intent_(intent) {}
-
-  virtual ~ParameterValueMapArg() = default;
-
-  void Accept(zetasql_fuzzer::FuzzTarget& function) override {
-    function.Visit(*this);
-  }
-
-  As GetIntent() { return intent_; }
-
- private:
-  As intent_;
 };
 }  // namespace zetasql_fuzzer
 

--- a/zetasql/fuzzing/component/arguments/parameter_value_argument.h
+++ b/zetasql/fuzzing/component/arguments/parameter_value_argument.h
@@ -24,32 +24,47 @@ namespace zetasql_fuzzer {
 
 enum ParameterValueAs { COLUMNS, PARAMETERS };
 
-class ParameterValueMapArg : public TypedArg<zetasql::ParameterValueMap> {
+template <typename ArgType>
+class ParameterValueContainerArg : public TypedArg<ArgType> {
  public:
-  ParameterValueMapArg() = delete;
-  ParameterValueMapArg(const ParameterValueMapArg&) = delete;
-  ParameterValueMapArg& operator=(const ParameterValueMapArg&) = delete;
+  ParameterValueContainerArg() = delete;
+  ParameterValueContainerArg(const ParameterValueContainerArg&) = delete;
+  ParameterValueContainerArg& operator=(const ParameterValueContainerArg&) = delete;
 
-  ParameterValueMapArg(ParameterValueMapArg&&) = default;
-  ParameterValueMapArg& operator=(ParameterValueMapArg&&) = default;
+  ParameterValueContainerArg(ParameterValueContainerArg&&) = default;
+  ParameterValueContainerArg& operator=(ParameterValueContainerArg&&) = default;
 
-  ParameterValueMapArg(const zetasql::ParameterValueMap& value, ParameterValueAs intent)
-      : TypedArg(value), intent_(intent) {}
-  ParameterValueMapArg(zetasql::ParameterValueMap&& value, ParameterValueAs intent)
-      : TypedArg(value), intent_(intent) {}
-  ParameterValueMapArg(std::unique_ptr<zetasql::ParameterValueMap> pointer, ParameterValueAs intent)
-      : TypedArg(std::move(pointer)), intent_(intent) {}
+  ParameterValueContainerArg(const ArgType& value, ParameterValueAs intent)
+      : TypedArg<ArgType>(value), intent_(intent) {}
+  ParameterValueContainerArg(ArgType&& value, ParameterValueAs intent)
+      : TypedArg<ArgType>(value), intent_(intent) {}
+  ParameterValueContainerArg(std::unique_ptr<ArgType> pointer, ParameterValueAs intent)
+      : TypedArg<ArgType>(std::move(pointer)), intent_(intent) {}
 
-  virtual ~ParameterValueMapArg() = default;
-
-  void Accept(zetasql_fuzzer::FuzzTarget& function) override {
-    function.Visit(*this);
-  }
+  virtual ~ParameterValueContainerArg() = default;
 
   ParameterValueAs GetIntent() { return intent_; }
 
  private:
   ParameterValueAs intent_;
+};
+
+class ParameterValueMapArg : public ParameterValueContainerArg<zetasql::ParameterValueMap> {
+ public:
+  using ParameterValueContainerArg::ParameterValueContainerArg;
+  virtual ~ParameterValueMapArg() = default;
+  void Accept(zetasql_fuzzer::FuzzTarget& function) override {
+    function.Visit(*this);
+  }
+};
+
+class ParameterValueListArg : public ParameterValueContainerArg<zetasql::ParameterValueList> {
+ public:
+  using ParameterValueContainerArg::ParameterValueContainerArg;
+  virtual ~ParameterValueListArg() = default;
+  void Accept(zetasql_fuzzer::FuzzTarget& function) override {
+    function.Visit(*this);
+  }
 };
 }  // namespace zetasql_fuzzer
 

--- a/zetasql/fuzzing/component/arguments/parameter_value_argument.h
+++ b/zetasql/fuzzing/component/arguments/parameter_value_argument.h
@@ -1,0 +1,56 @@
+//
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef ZETASQL_FUZZING_PARAMETER_VALUE_ARGUMENT_H
+#define ZETASQL_FUZZING_PARAMETER_VALUE_ARGUMENT_H
+
+#include "zetasql/fuzzing/component/arguments/argument.h"
+#include "zetasql/public/evaluator_base.h"
+
+namespace zetasql_fuzzer {
+
+enum ParameterValueAs { COLUMNS, PARAMETERS };
+
+class ParameterValueMapArg : public TypedArg<zetasql::ParameterValueMap> {
+ public:
+  ParameterValueMapArg() = delete;
+  ParameterValueMapArg(const ParameterValueMapArg&) = delete;
+  ParameterValueMapArg& operator=(const ParameterValueMapArg&) = delete;
+
+  ParameterValueMapArg(ParameterValueMapArg&&) = default;
+  ParameterValueMapArg& operator=(ParameterValueMapArg&&) = default;
+
+  ParameterValueMapArg(const zetasql::ParameterValueMap& value, ParameterValueAs intent)
+      : TypedArg(value), intent_(intent) {}
+  ParameterValueMapArg(zetasql::ParameterValueMap&& value, ParameterValueAs intent)
+      : TypedArg(value), intent_(intent) {}
+  ParameterValueMapArg(std::unique_ptr<zetasql::ParameterValueMap> pointer, ParameterValueAs intent)
+      : TypedArg(std::move(pointer)), intent_(intent) {}
+
+  virtual ~ParameterValueMapArg() = default;
+
+  void Accept(zetasql_fuzzer::FuzzTarget& function) override {
+    function.Visit(*this);
+  }
+
+  ParameterValueAs GetIntent() { return intent_; }
+
+ private:
+  ParameterValueAs intent_;
+};
+}  // namespace zetasql_fuzzer
+
+#endif  // ZETASQL_FUZZING_PARAMETER_VALUE_ARGUMENT_H

--- a/zetasql/fuzzing/component/fuzz_targets/fuzz_target.h
+++ b/zetasql/fuzzing/component/fuzz_targets/fuzz_target.h
@@ -27,18 +27,21 @@ namespace zetasql_fuzzer {
 
 class SQLStringArg;
 class ParameterValueMapArg;
+class ParameterValueListArg;
 
 class FuzzTarget {
  public:
   virtual ~FuzzTarget() = default;
   virtual void Visit(SQLStringArg& arg) { AbortVisit("SQLStringArg&"); }
   virtual void Visit(ParameterValueMapArg& arg) { AbortVisit("ParameterValueMapArg&"); }
+  virtual void Visit(ParameterValueListArg& arg) { AbortVisit("ParameterValueListArg&"); }
   virtual void Execute() = 0;
 
  protected:
-  static const zetasql::ParameterValueMap& GetOrDefault(
-      const std::unique_ptr<zetasql::ParameterValueMap>& ptr) {
-    static const zetasql::ParameterValueMap DEFAULT_VALUE_MAP;
+  template <typename T>
+  static const T& GetOrDefault(
+      const std::unique_ptr<T>& ptr) {
+    static const T DEFAULT_VALUE_MAP;
     return ptr ? *ptr : DEFAULT_VALUE_MAP;
   }
 

--- a/zetasql/fuzzing/component/fuzz_targets/fuzz_target.h
+++ b/zetasql/fuzzing/component/fuzz_targets/fuzz_target.h
@@ -34,6 +34,13 @@ class FuzzTarget {
   virtual void Visit(ParameterValueMapArg& arg) { AbortVisit("ParameterValueMapArg&"); }
   virtual void Execute() = 0;
 
+ protected:
+  static const zetasql::ParameterValueMap& GetOrDefault(
+      const std::unique_ptr<zetasql::ParameterValueMap>& ptr) {
+    static const zetasql::ParameterValueMap DEFAULT_VALUE_MAP;
+    return ptr ? *ptr : DEFAULT_VALUE_MAP;
+  }
+
  private:
   void AbortVisit(const std::string& type) {
     LOG(FATAL) << "#Visit(" << type

--- a/zetasql/fuzzing/component/fuzz_targets/fuzz_target.h
+++ b/zetasql/fuzzing/component/fuzz_targets/fuzz_target.h
@@ -21,14 +21,17 @@
 #include <string>
 
 #include "zetasql/base/logging.h"
+#include "zetasql/public/evaluator_base.h"
 
 namespace zetasql_fuzzer {
 
 class SQLStringArg;
+class ParameterValueMapArg;
 
 class FuzzTarget {
  public:
   virtual void Visit(SQLStringArg& arg) { AbortVisit("SQLStringArg&"); }
+  virtual void Visit(ParameterValueMapArg& arg) { AbortVisit("ParameterValueMapArg&"); }
   virtual void Execute() = 0;
 
  private:

--- a/zetasql/fuzzing/component/fuzz_targets/fuzz_target.h
+++ b/zetasql/fuzzing/component/fuzz_targets/fuzz_target.h
@@ -30,6 +30,7 @@ class ParameterValueMapArg;
 
 class FuzzTarget {
  public:
+  virtual ~FuzzTarget() = default;
   virtual void Visit(SQLStringArg& arg) { AbortVisit("SQLStringArg&"); }
   virtual void Visit(ParameterValueMapArg& arg) { AbortVisit("ParameterValueMapArg&"); }
   virtual void Execute() = 0;

--- a/zetasql/fuzzing/component/fuzz_targets/prepared_expression_positional_target.cc
+++ b/zetasql/fuzzing/component/fuzz_targets/prepared_expression_positional_target.cc
@@ -1,0 +1,60 @@
+//
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "zetasql/fuzzing/component/fuzz_targets/prepared_expression_positional_target.h"
+
+#include "zetasql/base/logging.h"
+#include "zetasql/fuzzing/component/arguments/argument.h"
+#include "zetasql/fuzzing/component/arguments/parameter_value_argument.h"
+#include "zetasql/public/evaluator.h"
+
+namespace zetasql_fuzzer {
+
+void PreparedExpressionPositionalTarget::Visit(SQLStringArg& arg) {
+  sql_expression_ = arg.Release().ValueOrDie();
+}
+
+void PreparedExpressionPositionalTarget::Visit(ParameterValueMapArg& arg) {
+  switch (arg.GetIntent()) {
+    case ParameterValueAs::COLUMNS:
+      columns_ = arg.Release().ValueOrDie();
+      return;
+    default:
+      LOG(FATAL)
+          << "Unhandled ParameterValueMapArg in PreparedExpressionPositionalTarget";
+  }
+}
+
+void PreparedExpressionPositionalTarget::Visit(ParameterValueListArg& arg) {
+  switch (arg.GetIntent()) {
+    case ParameterValueAs::PARAMETERS:
+      parameters_ = arg.Release().ValueOrDie();
+      return;
+    default:
+      LOG(FATAL)
+          << "Unhandled ParameterValueListArg in PreparedExpressionPositionalTarget";
+  }
+}
+
+void PreparedExpressionPositionalTarget::Execute() {
+  if (!sql_expression_) {
+    LOG(FATAL) << "SQL expression not found";
+  }
+  zetasql::PreparedExpression expression(*sql_expression_);
+  expression.ExecuteWithPositionalParams(GetOrDefault(columns_), GetOrDefault(parameters_));
+}
+
+}  // namespace zetasql_fuzzer

--- a/zetasql/fuzzing/component/fuzz_targets/prepared_expression_positional_target.h
+++ b/zetasql/fuzzing/component/fuzz_targets/prepared_expression_positional_target.h
@@ -1,0 +1,39 @@
+//
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef ZETASQL_FUZZING_PREPARED_EXPRESSION_POSITIONAL_TARGET_H
+#define ZETASQL_FUZZING_PREPARED_EXPRESSION_POSITIONAL_TARGET_H
+
+#include "zetasql/fuzzing/component/fuzz_targets/fuzz_target.h"
+
+namespace zetasql_fuzzer {
+
+class PreparedExpressionPositionalTarget : public FuzzTarget {
+ public:
+  void Visit(SQLStringArg& sql) override;
+  void Visit(ParameterValueMapArg& arg) override;
+  void Visit(ParameterValueListArg& arg) override;
+  void Execute() override;
+
+ private:
+  std::unique_ptr<std::string> sql_expression_;
+  std::unique_ptr<zetasql::ParameterValueMap> columns_;
+  std::unique_ptr<zetasql::ParameterValueList> parameters_;
+};
+
+}  // namespace zetasql_fuzzer
+
+#endif  // ZETASQL_FUZZING_PREPARED_EXPRESSION_POSITIONAL_TARGET_H

--- a/zetasql/fuzzing/component/fuzz_targets/prepared_expression_target.cc
+++ b/zetasql/fuzzing/component/fuzz_targets/prepared_expression_target.cc
@@ -23,16 +23,16 @@
 namespace zetasql_fuzzer {
 
 void PreparedExpressionTarget::Visit(SQLStringArg& arg) {
-  sql_expression = arg.Release().ValueOrDie();
+  sql_expression_ = arg.Release().ValueOrDie();
 }
 
 void PreparedExpressionTarget::Visit(ParameterValueMapArg& arg) {
   switch (arg.GetIntent()) {
     case ParameterValueMapArg::As::COLUMNS:
-      columns = arg.Release().ValueOrDie();
+      columns_ = arg.Release().ValueOrDie();
       return;
     case ParameterValueMapArg::As::PARAMETERS:
-      parameters = arg.Release().ValueOrDie();
+      parameters_ = arg.Release().ValueOrDie();
       return;
     default:
       LOG(FATAL)
@@ -41,11 +41,11 @@ void PreparedExpressionTarget::Visit(ParameterValueMapArg& arg) {
 }
 
 void PreparedExpressionTarget::Execute() {
-  if (!sql_expression) {
+  if (!sql_expression_) {
     LOG(FATAL) << "SQL expression not found";
   }
-  zetasql::PreparedExpression expression(*sql_expression);
-  expression.Execute(*columns, *parameters);
+  zetasql::PreparedExpression expression(*sql_expression_);
+  expression.Execute(GetOrDefault(columns_), GetOrDefault(parameters_));
 }
 
 }  // namespace zetasql_fuzzer

--- a/zetasql/fuzzing/component/fuzz_targets/prepared_expression_target.cc
+++ b/zetasql/fuzzing/component/fuzz_targets/prepared_expression_target.cc
@@ -26,12 +26,24 @@ void PreparedExpressionTarget::Visit(SQLStringArg& arg) {
   sql_expression = arg.Release().ValueOrDie();
 }
 
+void PreparedExpressionTarget::Visit(ParameterValueMapArg& arg) {
+  switch (arg.GetIntent()) {
+    case ParameterValueMapArg::As::COLUMNS:
+      columns = arg.Release().ValueOrDie();
+      return;
+
+    default:
+      LOG(FATAL)
+          << "Unhandled ParameterValueMapArg in PreparedExpressionTarget";
+  }
+}
+
 void PreparedExpressionTarget::Execute() {
   if (!sql_expression) {
     LOG(FATAL) << "SQL expression not found";
   }
   zetasql::PreparedExpression expression(*sql_expression);
-  expression.Execute();
+  expression.Execute(*columns);
 }
 
 }  // namespace zetasql_fuzzer

--- a/zetasql/fuzzing/component/fuzz_targets/prepared_expression_target.cc
+++ b/zetasql/fuzzing/component/fuzz_targets/prepared_expression_target.cc
@@ -18,6 +18,7 @@
 
 #include "zetasql/base/logging.h"
 #include "zetasql/fuzzing/component/arguments/argument.h"
+#include "zetasql/fuzzing/component/arguments/parameter_value_argument.h"
 #include "zetasql/public/evaluator.h"
 
 namespace zetasql_fuzzer {
@@ -28,10 +29,10 @@ void PreparedExpressionTarget::Visit(SQLStringArg& arg) {
 
 void PreparedExpressionTarget::Visit(ParameterValueMapArg& arg) {
   switch (arg.GetIntent()) {
-    case ParameterValueMapArg::As::COLUMNS:
+    case ParameterValueAs::COLUMNS:
       columns_ = arg.Release().ValueOrDie();
       return;
-    case ParameterValueMapArg::As::PARAMETERS:
+    case ParameterValueAs::PARAMETERS:
       parameters_ = arg.Release().ValueOrDie();
       return;
     default:

--- a/zetasql/fuzzing/component/fuzz_targets/prepared_expression_target.cc
+++ b/zetasql/fuzzing/component/fuzz_targets/prepared_expression_target.cc
@@ -31,7 +31,9 @@ void PreparedExpressionTarget::Visit(ParameterValueMapArg& arg) {
     case ParameterValueMapArg::As::COLUMNS:
       columns = arg.Release().ValueOrDie();
       return;
-
+    case ParameterValueMapArg::As::PARAMETERS:
+      parameters = arg.Release().ValueOrDie();
+      return;
     default:
       LOG(FATAL)
           << "Unhandled ParameterValueMapArg in PreparedExpressionTarget";
@@ -43,7 +45,7 @@ void PreparedExpressionTarget::Execute() {
     LOG(FATAL) << "SQL expression not found";
   }
   zetasql::PreparedExpression expression(*sql_expression);
-  expression.Execute(*columns);
+  expression.Execute(*columns, *parameters);
 }
 
 }  // namespace zetasql_fuzzer

--- a/zetasql/fuzzing/component/fuzz_targets/prepared_expression_target.h
+++ b/zetasql/fuzzing/component/fuzz_targets/prepared_expression_target.h
@@ -28,11 +28,9 @@ class PreparedExpressionTarget : public FuzzTarget {
   void Execute() override;
 
  private:
-  std::unique_ptr<std::string> sql_expression;
-  std::unique_ptr<zetasql::ParameterValueMap> columns =
-      std::make_unique<zetasql::ParameterValueMap>();
-  std::unique_ptr<zetasql::ParameterValueMap> parameters =
-      std::make_unique<zetasql::ParameterValueMap>();
+  std::unique_ptr<std::string> sql_expression_;
+  std::unique_ptr<zetasql::ParameterValueMap> columns_;
+  std::unique_ptr<zetasql::ParameterValueMap> parameters_;
 };
 
 }  // namespace zetasql_fuzzer

--- a/zetasql/fuzzing/component/fuzz_targets/prepared_expression_target.h
+++ b/zetasql/fuzzing/component/fuzz_targets/prepared_expression_target.h
@@ -31,6 +31,8 @@ class PreparedExpressionTarget : public FuzzTarget {
   std::unique_ptr<std::string> sql_expression;
   std::unique_ptr<zetasql::ParameterValueMap> columns =
       std::make_unique<zetasql::ParameterValueMap>();
+  std::unique_ptr<zetasql::ParameterValueMap> parameters =
+      std::make_unique<zetasql::ParameterValueMap>();
 };
 
 }  // namespace zetasql_fuzzer

--- a/zetasql/fuzzing/component/fuzz_targets/prepared_expression_target.h
+++ b/zetasql/fuzzing/component/fuzz_targets/prepared_expression_target.h
@@ -24,10 +24,13 @@ namespace zetasql_fuzzer {
 class PreparedExpressionTarget : public FuzzTarget {
  public:
   void Visit(SQLStringArg& sql) override;
+  void Visit(ParameterValueMapArg& arg) override;
   void Execute() override;
 
  private:
   std::unique_ptr<std::string> sql_expression;
+  std::unique_ptr<zetasql::ParameterValueMap> columns =
+      std::make_unique<zetasql::ParameterValueMap>();
 };
 
 }  // namespace zetasql_fuzzer

--- a/zetasql/fuzzing/pipelined_expression_fuzzer.cc
+++ b/zetasql/fuzzing/pipelined_expression_fuzzer.cc
@@ -24,7 +24,7 @@ using zetasql_fuzzer::GetParam;
 using zetasql_fuzzer::GetProtoExpr;
 using zetasql_fuzzer::PreparedExpressionTarget;
 
-using As = zetasql_fuzzer::ParameterValueMapArg::As;
+using As = zetasql_fuzzer::ParameterValueAs;
 
 ZETASQL_PROTO_FUZZER(Expression, PreparedExpressionTarget, GetProtoExpr,
                      GetParam<As::COLUMNS>, GetParam<As::PARAMETERS>);

--- a/zetasql/fuzzing/pipelined_expression_fuzzer.cc
+++ b/zetasql/fuzzing/pipelined_expression_fuzzer.cc
@@ -20,10 +20,11 @@
 #include "zetasql/fuzzing/protobuf/zetasql_expression_grammar.pb.h"
 
 using zetasql_expression_grammar::Expression;
+using zetasql_fuzzer::GetParam;
 using zetasql_fuzzer::GetProtoExpr;
 using zetasql_fuzzer::PreparedExpressionTarget;
+
 using As = zetasql_fuzzer::ParameterValueMapArg::As;
 
 ZETASQL_PROTO_FUZZER(Expression, PreparedExpressionTarget, GetProtoExpr,
-                     zetasql_fuzzer::GetParam<As::COLUMNS>);
-// , GetColumns);
+                     GetParam<As::COLUMNS>, GetParam<As::PARAMETERS>);

--- a/zetasql/fuzzing/pipelined_expression_fuzzer.cc
+++ b/zetasql/fuzzing/pipelined_expression_fuzzer.cc
@@ -22,5 +22,8 @@
 using zetasql_expression_grammar::Expression;
 using zetasql_fuzzer::GetProtoExpr;
 using zetasql_fuzzer::PreparedExpressionTarget;
+using As = zetasql_fuzzer::ParameterValueMapArg::As;
 
-ZETASQL_PROTO_FUZZER(Expression, PreparedExpressionTarget, GetProtoExpr);
+ZETASQL_PROTO_FUZZER(Expression, PreparedExpressionTarget, GetProtoExpr,
+                     zetasql_fuzzer::GetParam<As::COLUMNS>);
+// , GetColumns);

--- a/zetasql/fuzzing/positional_param_expression_fuzzer.cc
+++ b/zetasql/fuzzing/positional_param_expression_fuzzer.cc
@@ -1,0 +1,31 @@
+//
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "zetasql/fuzzing/component/fuzz_targets/prepared_expression_positional_target.h"
+#include "zetasql/fuzzing/fuzzer_macro.h"
+#include "zetasql/fuzzing/protobuf/argument_extractors.h"
+#include "zetasql/fuzzing/protobuf/zetasql_expression_grammar.pb.h"
+
+using zetasql_expression_grammar::Expression;
+using zetasql_fuzzer::GetParam;
+using zetasql_fuzzer::GetPositionalParam;
+using zetasql_fuzzer::GetProtoExpr;
+using zetasql_fuzzer::PreparedExpressionPositionalTarget;
+
+using As = zetasql_fuzzer::ParameterValueAs;
+
+ZETASQL_PROTO_FUZZER(Expression, PreparedExpressionPositionalTarget, GetProtoExpr,
+                     GetParam<As::COLUMNS>, GetPositionalParam<As::PARAMETERS>);

--- a/zetasql/fuzzing/protobuf/BUILD
+++ b/zetasql/fuzzing/protobuf/BUILD
@@ -26,12 +26,15 @@ package(
 
 cc_library(
     name = "argument_extractors",
+    srcs = [ "argument_extractors.cc" ],
     hdrs = [ "argument_extractors.h", ],
     deps = [
         ":zetasql_expression_cc_proto",
         "//zetasql/fuzzing/component:fuzz_target",
+        "//zetasql/fuzzing/component:parameter_value_argument",
         "//zetasql/fuzzing/protobuf/internal:zetasql_expression_extractor",
         "//zetasql/fuzzing/protobuf/internal:parameter_value_map_extractor",
+        "//zetasql/base:logging",
     ]
 )
 

--- a/zetasql/fuzzing/protobuf/BUILD
+++ b/zetasql/fuzzing/protobuf/BUILD
@@ -34,6 +34,7 @@ cc_library(
         "//zetasql/fuzzing/component:parameter_value_argument",
         "//zetasql/fuzzing/protobuf/internal:zetasql_expression_extractor",
         "//zetasql/fuzzing/protobuf/internal:parameter_value_map_extractor",
+        "//zetasql/fuzzing/protobuf/internal:parameter_value_list_extractor",
         "//zetasql/base:logging",
     ]
 )

--- a/zetasql/fuzzing/protobuf/BUILD
+++ b/zetasql/fuzzing/protobuf/BUILD
@@ -59,13 +59,21 @@ cc_proto_library(
     deps = [ ":zetasql_expression_proto", ],
 )
 
+cc_proto_library(
+    name = "parameter_cc_proto",
+    deps = [ ":parameter_proto"],
+)
+
 proto_library(
     name = "zetasql_expression_proto",
     srcs = [ "zetasql_expression_grammar.proto", ],
-    deps = [ ":parameter_proto", ]
+    deps = [ 
+        ":parameter_proto", 
+    ]
 )
 
 proto_library(
     name = "parameter_proto",
-    srcs = [ "parameter_grammar.proto", ]
+    srcs = [ "parameter_grammar.proto", ],
+    deps = [ "//zetasql/public:type_proto" ]
 )

--- a/zetasql/fuzzing/protobuf/BUILD
+++ b/zetasql/fuzzing/protobuf/BUILD
@@ -31,6 +31,7 @@ cc_library(
         ":zetasql_expression_cc_proto",
         "//zetasql/fuzzing/component:fuzz_target",
         "//zetasql/fuzzing/protobuf/internal:zetasql_expression_extractor",
+        "//zetasql/fuzzing/protobuf/internal:parameter_value_map_extractor",
     ]
 )
 
@@ -38,7 +39,6 @@ cc_test(
     name = "zetasql_expression_proto_to_string_test",
     srcs = ["zetasql_expression_proto_to_string_test.cc"],
     deps = [
-        ":zetasql_expression_cc_proto",
         ":zetasql_expression_proto_to_string",
         "@com_google_googletest//:gtest_main",
     ],

--- a/zetasql/fuzzing/protobuf/argument_extractors.cc
+++ b/zetasql/fuzzing/protobuf/argument_extractors.cc
@@ -1,0 +1,57 @@
+//
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "zetasql/fuzzing/protobuf/argument_extractors.h"
+
+#include "zetasql/base/logging.h"
+
+namespace zetasql_fuzzer {
+
+namespace {
+constexpr parameter_grammar::Identifier::Type GetType(
+    zetasql_fuzzer::ParameterValueAs type) {
+  switch (type) {
+    case ParameterValueAs::COLUMNS:
+      return parameter_grammar::Identifier::COLUMN;
+    case ParameterValueAs::PARAMETERS:
+      return parameter_grammar::Identifier::PARAMETER;
+    default:
+      LOG(FATAL)
+          << "Unhandled ParameterValueAs to Identifier::Type transformation.";
+  }
+}
+}  // namespace
+
+std::unique_ptr<Argument> GetProtoExpr(
+    const zetasql_expression_grammar::Expression& expression) {
+  zetasql_fuzzer::internal::SQLExprExtractor extractor;
+  extractor.Extract(expression);
+  return std::make_unique<SQLStringArg>(extractor.Data());
+}
+
+template <ParameterValueAs Intent>
+std::unique_ptr<Argument> GetParam(
+    const zetasql_expression_grammar::Expression& expression) {
+  zetasql_fuzzer::internal::ParameterValueMapExtractor extractor(GetType(Intent));
+  extractor.Extract(expression);
+  return std::make_unique<ParameterValueMapArg>(extractor.Data(), Intent);
+}
+
+template std::unique_ptr<Argument> GetParam<ParameterValueAs::COLUMNS>(
+    const zetasql_expression_grammar::Expression& expression);
+template std::unique_ptr<Argument> GetParam<ParameterValueAs::PARAMETERS>(
+    const zetasql_expression_grammar::Expression& expression);
+}  // namespace zetasql_fuzzer

--- a/zetasql/fuzzing/protobuf/argument_extractors.cc
+++ b/zetasql/fuzzing/protobuf/argument_extractors.cc
@@ -17,6 +17,9 @@
 #include "zetasql/fuzzing/protobuf/argument_extractors.h"
 
 #include "zetasql/base/logging.h"
+#include "zetasql/fuzzing/protobuf/internal/parameter_value_list_extractor.h"
+#include "zetasql/fuzzing/protobuf/internal/parameter_value_map_extractor.h"
+#include "zetasql/fuzzing/protobuf/internal/zetasql_expression_extractor.h"
 
 namespace zetasql_fuzzer {
 
@@ -53,5 +56,18 @@ std::unique_ptr<Argument> GetParam(
 template std::unique_ptr<Argument> GetParam<ParameterValueAs::COLUMNS>(
     const zetasql_expression_grammar::Expression& expression);
 template std::unique_ptr<Argument> GetParam<ParameterValueAs::PARAMETERS>(
+    const zetasql_expression_grammar::Expression& expression);
+
+template <ParameterValueAs Intent>
+std::unique_ptr<Argument> GetPositionalParam(
+    const zetasql_expression_grammar::Expression& expression) {
+  zetasql_fuzzer::internal::ParameterValueListExtractor extractor(GetType(Intent));
+  extractor.Extract(expression);
+  return std::make_unique<ParameterValueListArg>(extractor.Data(), Intent);
+}
+
+template std::unique_ptr<Argument> GetPositionalParam<ParameterValueAs::COLUMNS>(
+    const zetasql_expression_grammar::Expression& expression);
+template std::unique_ptr<Argument> GetPositionalParam<ParameterValueAs::PARAMETERS>(
     const zetasql_expression_grammar::Expression& expression);
 }  // namespace zetasql_fuzzer

--- a/zetasql/fuzzing/protobuf/argument_extractors.h
+++ b/zetasql/fuzzing/protobuf/argument_extractors.h
@@ -19,8 +19,6 @@
 
 #include "zetasql/fuzzing/component/arguments/argument.h"
 #include "zetasql/fuzzing/component/arguments/parameter_value_argument.h"
-#include "zetasql/fuzzing/protobuf/internal/parameter_value_map_extractor.h"
-#include "zetasql/fuzzing/protobuf/internal/zetasql_expression_extractor.h"
 #include "zetasql/fuzzing/protobuf/zetasql_expression_grammar.pb.h"
 
 namespace zetasql_fuzzer {
@@ -30,6 +28,10 @@ std::unique_ptr<Argument> GetProtoExpr(
 
 template <ParameterValueAs Intent>
 extern std::unique_ptr<Argument> GetParam(
+    const zetasql_expression_grammar::Expression& expression);
+
+template <ParameterValueAs Intent>
+extern std::unique_ptr<Argument> GetPositionalParam(
     const zetasql_expression_grammar::Expression& expression);
 }  // namespace zetasql_fuzzer
 

--- a/zetasql/fuzzing/protobuf/argument_extractors.h
+++ b/zetasql/fuzzing/protobuf/argument_extractors.h
@@ -20,6 +20,7 @@
 #include "zetasql/fuzzing/component/arguments/argument.h"
 #include "zetasql/fuzzing/protobuf/zetasql_expression_grammar.pb.h"
 #include "zetasql/fuzzing/protobuf/internal/zetasql_expression_extractor.h"
+#include "zetasql/fuzzing/protobuf/internal/parameter_value_map_extractor.h"
 
 namespace zetasql_fuzzer {
 
@@ -27,6 +28,13 @@ std::unique_ptr<Argument> GetProtoExpr(const zetasql_expression_grammar::Express
   zetasql_fuzzer::internal::SQLExprExtractor extractor;
   extractor.Extract(expression);
   return std::make_unique<SQLStringArg>(extractor.Data());
+}
+
+template <zetasql_fuzzer::ParameterValueMapArg::As Intent>
+std::unique_ptr<Argument> GetParam(const zetasql_expression_grammar::Expression& expression) {
+  zetasql_fuzzer::internal::ParameterValueMapExtractor extractor;
+  extractor.Extract(expression);
+  return std::make_unique<ParameterValueMapArg>(extractor.Data(), Intent);
 }
 
 }  // namespace zetasql_fuzzer

--- a/zetasql/fuzzing/protobuf/argument_extractors.h
+++ b/zetasql/fuzzing/protobuf/argument_extractors.h
@@ -18,25 +18,19 @@
 #define ZETASQL_FUZZING_ARGUMENT_EXTRACTORS_H
 
 #include "zetasql/fuzzing/component/arguments/argument.h"
-#include "zetasql/fuzzing/protobuf/zetasql_expression_grammar.pb.h"
-#include "zetasql/fuzzing/protobuf/internal/zetasql_expression_extractor.h"
+#include "zetasql/fuzzing/component/arguments/parameter_value_argument.h"
 #include "zetasql/fuzzing/protobuf/internal/parameter_value_map_extractor.h"
+#include "zetasql/fuzzing/protobuf/internal/zetasql_expression_extractor.h"
+#include "zetasql/fuzzing/protobuf/zetasql_expression_grammar.pb.h"
 
 namespace zetasql_fuzzer {
 
-std::unique_ptr<Argument> GetProtoExpr(const zetasql_expression_grammar::Expression& expression) {
-  zetasql_fuzzer::internal::SQLExprExtractor extractor;
-  extractor.Extract(expression);
-  return std::make_unique<SQLStringArg>(extractor.Data());
-}
+std::unique_ptr<Argument> GetProtoExpr(
+    const zetasql_expression_grammar::Expression& expression);
 
-template <zetasql_fuzzer::ParameterValueMapArg::As Intent>
-std::unique_ptr<Argument> GetParam(const zetasql_expression_grammar::Expression& expression) {
-  zetasql_fuzzer::internal::ParameterValueMapExtractor extractor;
-  extractor.Extract(expression);
-  return std::make_unique<ParameterValueMapArg>(extractor.Data(), Intent);
-}
-
+template <ParameterValueAs Intent>
+extern std::unique_ptr<Argument> GetParam(
+    const zetasql_expression_grammar::Expression& expression);
 }  // namespace zetasql_fuzzer
 
 #endif  //ZETASQL_FUZZING_ARGUMENT_EXTRACTORS_H

--- a/zetasql/fuzzing/protobuf/argument_extractors.h
+++ b/zetasql/fuzzing/protobuf/argument_extractors.h
@@ -24,7 +24,7 @@
 namespace zetasql_fuzzer {
 
 std::unique_ptr<Argument> GetProtoExpr(const zetasql_expression_grammar::Expression& expression) {
-  zetasql_fuzzer::internal::ProtoExprExtractor extractor;
+  zetasql_fuzzer::internal::SQLExprExtractor extractor;
   extractor.Extract(expression);
   return std::make_unique<SQLStringArg>(extractor.Data());
 }

--- a/zetasql/fuzzing/protobuf/internal/BUILD
+++ b/zetasql/fuzzing/protobuf/internal/BUILD
@@ -54,13 +54,32 @@ cc_test(
 )
 
 cc_library(
+    name = "literal_value_extractor",
+    srcs = [ "literal_value_extractor.cc" ],
+    hdrs = [ "literal_value_extractor.h" ],
+    deps = [
+        "//zetasql/public:value",
+        "//zetasql/fuzzing/protobuf:parameter_cc_proto",
+    ]
+)
+
+cc_test(
+    name = "literal_value_extractor_test",
+    srcs = [ "literal_value_extractor_test.cc" ],
+    deps = [
+        ":literal_value_extractor",
+        "//zetasql/public:numeric_value",
+        "@com_google_googletest//:gtest_main",
+    ]
+)
+
+cc_library(
     name = "parameter_value_map_extractor",
     srcs = [ "parameter_value_map_extractor.cc" ],
     hdrs = [ "parameter_value_map_extractor.h" ],
     deps = [
         ":syntax_tree_visitor",
-        "//zetasql/base:logging",
-        "//zetasql/public:value",
+        ":literal_value_extractor",
         "//zetasql/public:evaluator_base"
     ]
 )
@@ -70,7 +89,6 @@ cc_test(
     srcs = [ "parameter_value_map_extractor_test.cc" ],
     deps = [
         ":parameter_value_map_extractor",
-        "//zetasql/public:numeric_value",
         "@com_google_googletest//:gtest_main",
     ]
 )

--- a/zetasql/fuzzing/protobuf/internal/BUILD
+++ b/zetasql/fuzzing/protobuf/internal/BUILD
@@ -24,13 +24,22 @@ package(
 )
 
 cc_library(
+    name = "syntax_tree_visitor",
+    hdrs = [ "syntax_tree_visitor.h", ],
+    deps = [
+        "//zetasql/fuzzing/protobuf:parameter_cc_proto",
+        "//zetasql/fuzzing/protobuf:zetasql_expression_cc_proto",
+    ]
+)
+
+cc_library(
     name = "zetasql_expression_extractor",
     srcs = [ "zetasql_expression_extractor.cc", ],
     hdrs = [ "zetasql_expression_extractor.h", ],
     deps = [
-        "//zetasql/fuzzing/protobuf:zetasql_expression_cc_proto",
+        ":syntax_tree_visitor",
+        "//zetasql/base:logging",
         "@com_google_absl//absl/strings",
-        "@com_google_googletest//:gtest_prod",
     ]
 )
 
@@ -39,8 +48,29 @@ cc_test(
     srcs = [ "zetasql_expression_extractor_test.cc", ],
     deps = [
         ":zetasql_expression_extractor",
-        "//zetasql/fuzzing/protobuf:zetasql_expression_cc_proto",
+        "//zetasql/public:type",
         "@com_google_googletest//:gtest_main",
     ]
 )
 
+cc_library(
+    name = "parameter_value_map_extractor",
+    srcs = [ "parameter_value_map_extractor.cc" ],
+    hdrs = [ "parameter_value_map_extractor.h" ],
+    deps = [
+        ":syntax_tree_visitor",
+        "//zetasql/base:logging",
+        "//zetasql/public:value",
+        "//zetasql/public:evaluator_base"
+    ]
+)
+
+cc_test(
+    name = "parameter_value_map_extractor_test",
+    srcs = [ "parameter_value_map_extractor_test.cc" ],
+    deps = [
+        ":parameter_value_map_extractor",
+        "//zetasql/public:numeric_value",
+        "@com_google_googletest//:gtest_main",
+    ]
+)

--- a/zetasql/fuzzing/protobuf/internal/BUILD
+++ b/zetasql/fuzzing/protobuf/internal/BUILD
@@ -92,3 +92,23 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ]
 )
+
+cc_library(
+    name = "parameter_value_list_extractor",
+    srcs = [ "parameter_value_list_extractor.cc" ],
+    hdrs = [ "parameter_value_list_extractor.h" ],
+    deps = [
+        ":syntax_tree_visitor",
+        ":literal_value_extractor",
+        "//zetasql/public:evaluator_base"
+    ]
+)
+
+cc_test(
+    name = "parameter_value_list_extractor_test",
+    srcs = [ "parameter_value_list_extractor_test.cc" ],
+    deps = [
+        ":parameter_value_list_extractor",
+        "@com_google_googletest//:gtest_main",
+    ]
+)

--- a/zetasql/fuzzing/protobuf/internal/literal_value_extractor.cc
+++ b/zetasql/fuzzing/protobuf/internal/literal_value_extractor.cc
@@ -1,0 +1,99 @@
+//
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "zetasql/fuzzing/protobuf/internal/literal_value_extractor.h"
+
+using parameter_grammar::Identifier;
+using parameter_grammar::IntegerLiteral;
+using parameter_grammar::Literal;
+using parameter_grammar::NumericLiteral;
+using parameter_grammar::Whitespace;
+
+namespace zetasql_fuzzer {
+namespace internal {
+namespace LiteralValueExtractor {
+
+zetasql::Value Extract(const parameter_grammar::Literal& literal) {
+  switch (literal.literal_oneof_case()) {
+    case Literal::kBoolLiteral:
+      return zetasql::Value::Bool(literal.bool_literal());
+    case Literal::kNullLiteral:
+      return Extract(literal.null_literal());
+    case Literal::kBytesLiteral:
+      return zetasql::Value::Bytes(literal.bytes_literal());
+    case Literal::kStringLiteral:
+      return zetasql::Value::StringValue(literal.string_literal());
+    case Literal::kIntegerLiteral:
+      return Extract(literal.integer_literal());
+    case Literal::kNumericLiteral:
+      return Extract(literal.numeric_literal());
+    default:
+      return ExtractDefault(literal);
+  }
+}
+
+zetasql::Value Extract(const parameter_grammar::IntegerLiteral& integer) {
+  switch (integer.integer_oneof_case()) {
+    case IntegerLiteral::kInt32Literal:
+      return zetasql::Value::Int32(integer.int32_literal());
+    case IntegerLiteral::kInt64Literal:
+      return zetasql::Value::Int64(integer.int64_literal());
+    case IntegerLiteral::kUint32Literal:
+      return zetasql::Value::Uint32(integer.uint32_literal());
+    case IntegerLiteral::kUint64Literal:
+      return zetasql::Value::Uint64(integer.uint64_literal());
+    default:
+      return ExtractDefault(integer);
+  }
+}
+
+zetasql::Value Extract(const parameter_grammar::NumericLiteral& numeric) {
+  auto value(zetasql::NumericValue::FromString(numeric.value()));
+  if (value) {
+    return zetasql::Value::Numeric(value.value());
+  }
+  return zetasql::Value::Numeric((zetasql::NumericValue()));
+}
+
+zetasql::Value Extract(zetasql::TypeKind null_type) {
+  switch (null_type) {
+    case zetasql::TYPE_INT32:
+    case zetasql::TYPE_INT64:
+    case zetasql::TYPE_UINT32:
+    case zetasql::TYPE_UINT64:
+    case zetasql::TYPE_BOOL:
+    case zetasql::TYPE_FLOAT:
+    case zetasql::TYPE_DOUBLE:
+    case zetasql::TYPE_STRING:
+    case zetasql::TYPE_BYTES:
+    case zetasql::TYPE_TIMESTAMP:
+    case zetasql::TYPE_DATE:
+    case zetasql::TYPE_TIME:
+    case zetasql::TYPE_DATETIME:
+    case zetasql::TYPE_GEOGRAPHY:
+    case zetasql::TYPE_NUMERIC:
+    case zetasql::TYPE_BIGNUMERIC:
+      return zetasql::Value::Null(
+          zetasql::types::TypeFromSimpleTypeKind(null_type));
+    // Treat all other types as invalid type
+    default:
+      return zetasql::Value::Invalid();
+  }
+}
+
+}  // namespace LiteralValueExtractor
+}  // namespace internal
+}  // namespace zetasql_fuzzer

--- a/zetasql/fuzzing/protobuf/internal/literal_value_extractor.h
+++ b/zetasql/fuzzing/protobuf/internal/literal_value_extractor.h
@@ -1,0 +1,40 @@
+//
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef ZETASQL_FUZZING_LITERAL_VALUE_EXTRACTOR_H
+#define ZETASQL_FUZZING_LITERAL_VALUE_EXTRACTOR_H
+
+#include "zetasql/fuzzing/protobuf/parameter_grammar.pb.h"
+#include "zetasql/public/value.h"
+
+namespace zetasql_fuzzer {
+namespace internal {
+
+namespace LiteralValueExtractor {
+zetasql::Value Extract(const parameter_grammar::Literal& literal);
+zetasql::Value Extract(const parameter_grammar::IntegerLiteral& integer);
+zetasql::Value Extract(const parameter_grammar::NumericLiteral& numeric);
+zetasql::Value Extract(zetasql::TypeKind null_type);
+template <typename T>
+inline zetasql::Value ExtractDefault(const T& literal) {
+  return zetasql::Value::Bytes(literal.default_value().content());
+}
+}  // namespace LiteralValueExtractor
+
+}  // namespace internal
+}  // namespace zetasql_fuzzer
+
+#endif  // ZETASQL_FUZZING_LITERAL_VALUE_EXTRACTOR_H

--- a/zetasql/fuzzing/protobuf/internal/literal_value_extractor_test.cc
+++ b/zetasql/fuzzing/protobuf/internal/literal_value_extractor_test.cc
@@ -1,0 +1,205 @@
+//
+// Copyright 2020 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "zetasql/fuzzing/protobuf/internal/literal_value_extractor.h"
+
+#include <memory>
+#include <string>
+#include <tuple>
+
+#include "gtest/gtest.h"
+#include "zetasql/public/numeric_value.h"
+
+using parameter_grammar::IntegerLiteral;
+using parameter_grammar::Literal;
+using parameter_grammar::NumericLiteral;
+using parameter_grammar::Whitespace;
+
+namespace zetasql_fuzzer {
+namespace {
+  
+using ExtractLiteralCallback = std::function<zetasql::Value(void)>;
+class LiteralValueExtractorTest
+    : public ::testing::TestWithParam<
+          std::tuple<ExtractLiteralCallback, zetasql::Value>> {};
+
+TEST_P(LiteralValueExtractorTest, ExtractTest) {
+  EXPECT_EQ(std::get<0>(GetParam())(), std::get<1>(GetParam()));
+}
+
+ExtractLiteralCallback ExtractableNullLiteral(zetasql::TypeKind kind) {
+  return [kind]() {
+    Literal literal;
+    literal.set_null_literal(kind);
+    return internal::LiteralValueExtractor::Extract(literal);
+  };
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    NullLiteralValueTest, LiteralValueExtractorTest,
+    ::testing::Values(
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_INT32), zetasql::Value::NullInt32()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_INT64), zetasql::Value::NullInt64()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_UINT32), zetasql::Value::NullUint32()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_UINT64), zetasql::Value::NullUint64()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_BOOL), zetasql::Value::NullBool()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_FLOAT), zetasql::Value::NullFloat()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_DOUBLE), zetasql::Value::NullDouble()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_STRING), zetasql::Value::NullString()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_BYTES), zetasql::Value::NullBytes()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_DATE), zetasql::Value::NullDate()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_TIMESTAMP), zetasql::Value::NullTimestamp()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_TIME), zetasql::Value::NullTime()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_DATETIME), zetasql::Value::NullDatetime()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_GEOGRAPHY), zetasql::Value::NullGeography()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_NUMERIC), zetasql::Value::NullNumeric()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_BIGNUMERIC), zetasql::Value::NullBigNumeric()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::__TypeKind__switch_must_have_a_default__), zetasql::Value()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_UNKNOWN), zetasql::Value()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_ENUM), zetasql::Value()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_ARRAY), zetasql::Value()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_STRUCT), zetasql::Value()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_PROTO), zetasql::Value())
+    ));
+
+template <typename LiteralType>
+ExtractLiteralCallback ExtractableEmptyLiteral() {
+  return []() {
+    return internal::LiteralValueExtractor::Extract((LiteralType()));
+  };
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    EmptyLiteralTest, LiteralValueExtractorTest,
+    ::testing::Combine(
+        ::testing::Values(ExtractableEmptyLiteral<Literal>(),
+                          ExtractableEmptyLiteral<IntegerLiteral>()),
+        ::testing::Values(zetasql::Value::Bytes(""))));
+
+template <typename LiteralType>
+ExtractLiteralCallback ExtractableDefaultValue(const std::string& value) {
+  return [value]() {
+    LiteralType literal;
+    literal.mutable_default_value()->set_content(value);
+    return internal::LiteralValueExtractor::Extract(literal);
+  };
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    DefaultOneOfValueTest, LiteralValueExtractorTest,
+    ::testing::Values(
+        std::make_tuple(ExtractableDefaultValue<Literal>("default_lit"),
+                        zetasql::Value::Bytes("default_lit")),
+        std::make_tuple(ExtractableDefaultValue<IntegerLiteral>("default_int"),
+                        zetasql::Value::Bytes("default_int"))));
+
+ExtractLiteralCallback ExtractableStringLiteral(
+    const std::string& value) {
+  return [value]() {
+    Literal expr;
+    expr.set_string_literal(value);
+    return internal::LiteralValueExtractor::Extract(expr);
+  };
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    StringLiteralTest, LiteralValueExtractorTest,
+    ::testing::Values(std::make_tuple(ExtractableStringLiteral(""),
+                                      zetasql::Value::StringValue("")),
+                      std::make_tuple(ExtractableStringLiteral("tEsT"),
+                                      zetasql::Value::StringValue("tEsT"))));
+
+ExtractLiteralCallback ExtractableBytesLiteral(
+    const std::string& value) {
+  return [value]() {
+    Literal expr;
+    expr.set_bytes_literal(value);
+    return internal::LiteralValueExtractor::Extract(expr);
+  };
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BytesLiteralTest, LiteralValueExtractorTest,
+    ::testing::Values(
+        std::make_tuple(ExtractableBytesLiteral(""), zetasql::Value::Bytes("")),
+        std::make_tuple(ExtractableBytesLiteral("TeSt"), zetasql::Value::Bytes("TeSt")),
+        std::make_tuple(ExtractableBytesLiteral("\x01\x02"), zetasql::Value::Bytes("\x01\x02"))));
+
+template <IntegerLiteral::IntegerOneofCase IntegerType, typename T>
+ExtractLiteralCallback ExtractableIntegerLiteral(T value) {
+  return [value]() {
+    IntegerLiteral expression;
+    switch (IntegerType) {
+      case IntegerLiteral::kInt32Literal:
+        expression.set_int32_literal(value);
+        break;
+      case IntegerLiteral::kUint32Literal:
+        expression.set_uint32_literal(value);
+        break;
+      case IntegerLiteral::kInt64Literal:
+        expression.set_int64_literal(value);
+        break;
+      case IntegerLiteral::kUint64Literal:
+        expression.set_uint64_literal(value);
+        break;
+      default:
+        assert(false && "IntegerType for IntegerLiteralTest is wrongly set up");
+    }
+    return internal::LiteralValueExtractor::Extract(expression);
+  };
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  IntegerLiteralTest, LiteralValueExtractorTest,
+  ::testing::Values(
+    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kInt32Literal>(1), zetasql::Value::Int32(1)),
+    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kInt32Literal>(0), zetasql::Value::Int32(0)),
+    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kInt32Literal>(google::protobuf::kint32max), zetasql::Value::Int32(2147483647)),
+    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kInt32Literal>(google::protobuf::kint32min), zetasql::Value::Int32(-2147483648)),
+
+    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kUint32Literal>(1), zetasql::Value::Uint32(1)),
+    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kUint32Literal>(0), zetasql::Value::Uint32(0)),
+    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kUint32Literal>(google::protobuf::kuint32max), zetasql::Value::Uint32(4294967295)),
+
+    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kInt64Literal>(1), zetasql::Value::Int64(1)),
+    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kInt64Literal>(0), zetasql::Value::Int64(0)),
+    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kInt64Literal>(google::protobuf::kint64max), zetasql::Value::Int64(9223372036854775807)),
+    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kInt64Literal>(google::protobuf::kint64min), zetasql::Value::Int64(-9223372036854775808)),
+
+    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kUint64Literal>(1), zetasql::Value::Uint64(1)),
+    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kUint64Literal>(0), zetasql::Value::Uint64(0)),
+    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kUint64Literal>(google::protobuf::kuint64max), zetasql::Value::Uint64(18446744073709551615))
+  )
+);
+
+ExtractLiteralCallback ExtractableNumeric(const std::string& value) {
+  return [value]() {
+    NumericLiteral expression;
+    expression.set_value(value);
+    return internal::LiteralValueExtractor::Extract(expression);
+  };
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    NumericLiteralTest, LiteralValueExtractorTest,
+    ::testing::Values(
+      std::make_tuple(ExtractableNumeric("12345"), zetasql::Value::Numeric(zetasql::NumericValue(12345))),
+      std::make_tuple(ExtractableNumeric("123.45"), zetasql::Value::Numeric(zetasql::NumericValue::FromString("123.45").ValueOrDie())),
+      std::make_tuple(ExtractableNumeric("1234sdf"), zetasql::Value::Numeric(zetasql::NumericValue(0)))
+    ));
+
+}  // namespace
+}  // namespace zetasql_fuzzer

--- a/zetasql/fuzzing/protobuf/internal/parameter_value_list_extractor.cc
+++ b/zetasql/fuzzing/protobuf/internal/parameter_value_list_extractor.cc
@@ -1,0 +1,61 @@
+//
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "zetasql/fuzzing/protobuf/internal/parameter_value_list_extractor.h"
+
+#include "zetasql/fuzzing/protobuf/internal/literal_value_extractor.h"
+
+using zetasql_expression_grammar::BinaryOperation;
+using zetasql_expression_grammar::CompoundExpr;
+using zetasql_expression_grammar::Expression;
+
+namespace zetasql_fuzzer {
+namespace internal {
+
+void ParameterValueListExtractor::Extract(const zetasql_expression_grammar::Expression& expr) {
+  switch (expr.expr_oneof_case()) {
+    case Expression::kValue:
+      return Extract(expr.value());
+    case Expression::kExpr:
+      return Extract(expr.expr());
+    default:
+      return;
+  }
+}
+
+void ParameterValueListExtractor::Extract(const parameter_grammar::Value& value) {
+  if (value.has_as_variable() && extract_type_ == value.as_variable().type()) {
+      // Push back everything regardless of Value validity to preserve positional order
+      builder_.push_back(LiteralValueExtractor::Extract(value.literal()));
+  }
+}
+
+void ParameterValueListExtractor::Extract(const zetasql_expression_grammar::CompoundExpr& comp_expr) {
+  switch (comp_expr.compound_oneof_case()) {
+    case CompoundExpr::kBinaryOperation:
+      return Extract(comp_expr.binary_operation());
+    default:
+      return;
+  }
+}
+
+void ParameterValueListExtractor::Extract(const zetasql_expression_grammar::BinaryOperation& binary_operation) {
+  Extract(binary_operation.lhs());
+  Extract(binary_operation.rhs());
+}
+
+}  // namespace internal
+}  // namespace zetasql_fuzzer

--- a/zetasql/fuzzing/protobuf/internal/parameter_value_list_extractor.h
+++ b/zetasql/fuzzing/protobuf/internal/parameter_value_list_extractor.h
@@ -1,0 +1,53 @@
+//
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef ZETASQL_FUZZING_PARAMETER_VALUE_LIST_EXTRACTOR_H
+#define ZETASQL_FUZZING_PARAMETER_VALUE_LIST_EXTRACTOR_H
+
+#include "zetasql/fuzzing/protobuf/internal/syntax_tree_visitor.h"
+#include "zetasql/public/evaluator_base.h"
+
+namespace zetasql_fuzzer {
+namespace internal {
+
+class ParameterValueListExtractor : public ProtoExprExtractor<zetasql::ParameterValueList> {
+ public:
+  ParameterValueListExtractor() = delete;
+  ParameterValueListExtractor(const ParameterValueListExtractor&) = default;
+  ParameterValueListExtractor& operator=(const ParameterValueListExtractor&) = default;
+  ParameterValueListExtractor(ParameterValueListExtractor&&) = default;
+  ParameterValueListExtractor& operator=(ParameterValueListExtractor&&) = default;
+
+  ParameterValueListExtractor(parameter_grammar::Identifier::Type type)
+      : extract_type_(type) {}
+
+  virtual ~ParameterValueListExtractor() = default;
+
+  void Extract(const parameter_grammar::Value& value) override;
+  void Extract(const zetasql_expression_grammar::Expression& expr) override;
+  void Extract(const zetasql_expression_grammar::CompoundExpr& comp_expr) override;
+  void Extract(const zetasql_expression_grammar::BinaryOperation& binary_operation) override;
+  inline const zetasql::ParameterValueList& Data() override { return builder_; }
+
+ private:
+  zetasql::ParameterValueList builder_;
+  parameter_grammar::Identifier::Type extract_type_;
+};
+
+}  // namespace internal
+}  // namespace zetasql_fuzzer
+
+#endif  // ZETASQL_FUZZING_PARAMETER_VALUE_LIST_EXTRACTOR_H

--- a/zetasql/fuzzing/protobuf/internal/parameter_value_map_extractor.cc
+++ b/zetasql/fuzzing/protobuf/internal/parameter_value_map_extractor.cc
@@ -1,0 +1,138 @@
+//
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "zetasql/fuzzing/protobuf/internal/parameter_value_map_extractor.h"
+
+using parameter_grammar::Identifier;
+using parameter_grammar::IntegerLiteral;
+using parameter_grammar::Literal;
+using parameter_grammar::NumericLiteral;
+using parameter_grammar::Whitespace;
+using zetasql_expression_grammar::BinaryOperation;
+using zetasql_expression_grammar::CompoundExpr;
+using zetasql_expression_grammar::Expression;
+
+namespace zetasql_fuzzer {
+namespace internal {
+
+namespace LiteralValueExtractor {
+
+zetasql::Value Extract(const parameter_grammar::Literal& literal) {
+  switch (literal.literal_oneof_case()) {
+    case Literal::kBoolLiteral:
+      return zetasql::Value::Bool(literal.bool_literal());
+    case Literal::kNullLiteral:
+      return Extract(literal.null_literal());
+    case Literal::kBytesLiteral:
+      return zetasql::Value::Bytes(literal.bytes_literal());
+    case Literal::kStringLiteral:
+      return zetasql::Value::StringValue(literal.string_literal());
+    case Literal::kIntegerLiteral:
+      return Extract(literal.integer_literal());
+    case Literal::kNumericLiteral:
+      return Extract(literal.numeric_literal());
+    default:
+      LOG(FATAL) << "Unhandled LiteralExpr to Value conversion at "
+                    "ParameterValueMapExtractor";
+  }
+}
+
+zetasql::Value Extract(const parameter_grammar::IntegerLiteral& integer) {
+  switch (integer.integer_oneof_case()) {
+    case IntegerLiteral::kInt32Literal:
+      return zetasql::Value::Int32(integer.int32_literal());
+    case IntegerLiteral::kInt64Literal:
+      return zetasql::Value::Int64(integer.int64_literal());
+    case IntegerLiteral::kUint32Literal:
+      return zetasql::Value::Uint32(integer.uint32_literal());
+    case IntegerLiteral::kUint64Literal:
+      return zetasql::Value::Uint64(integer.uint64_literal());
+    default:
+      LOG(FATAL) << "Unhandled IntegerLiteral to Value conversion at "
+                    "ParameterValueMapExtractor";
+  }
+}
+
+zetasql::Value Extract(const parameter_grammar::NumericLiteral& numeric) {
+  // TODO: Handle ValueOrDie
+  return zetasql::Value::Numeric(
+      zetasql::NumericValue::FromString(numeric.value()).ValueOrDie());
+}
+
+zetasql::Value Extract(zetasql::TypeKind null_type) {
+  switch (null_type) {
+    case zetasql::TYPE_INT32:
+    case zetasql::TYPE_INT64:
+    case zetasql::TYPE_UINT32:
+    case zetasql::TYPE_UINT64:
+    case zetasql::TYPE_BOOL:
+    case zetasql::TYPE_FLOAT:
+    case zetasql::TYPE_DOUBLE:
+    case zetasql::TYPE_STRING:
+    case zetasql::TYPE_BYTES:
+    case zetasql::TYPE_TIMESTAMP:
+    case zetasql::TYPE_DATE:
+    case zetasql::TYPE_TIME:
+    case zetasql::TYPE_DATETIME:
+    case zetasql::TYPE_GEOGRAPHY:
+    case zetasql::TYPE_NUMERIC:
+    case zetasql::TYPE_BIGNUMERIC:
+      return zetasql::Value::Null(
+          zetasql::types::TypeFromSimpleTypeKind(null_type));
+    // Treat all other types as invalid type
+    default:
+      return zetasql::Value::Invalid();
+  }
+}
+
+}  // namespace LiteralValueExtractor
+
+void ParameterValueMapExtractor::Extract(const zetasql_expression_grammar::Expression& expr) {
+  switch (expr.expr_oneof_case()) {
+    case Expression::kValue:
+      return Extract(expr.value());
+    case Expression::kExpr:
+      return Extract(expr.expr());
+    default:
+      return;
+  }
+}
+
+void ParameterValueMapExtractor::Extract(const parameter_grammar::Value& value) {
+  if (value.has_as_variable()) {
+    zetasql::Value extracted(LiteralValueExtractor::Extract(value.literal()));
+    if (extracted.is_valid()) {
+      builder_[value.as_variable().name()] = extracted;
+    }
+  }
+}
+
+void ParameterValueMapExtractor::Extract(const zetasql_expression_grammar::CompoundExpr& comp_expr) {
+  switch (comp_expr.compound_oneof_case()) {
+    case CompoundExpr::kBinaryOperation:
+      return Extract(comp_expr.binary_operation());
+    default:
+      return;
+  }
+}
+
+void ParameterValueMapExtractor::Extract(const zetasql_expression_grammar::BinaryOperation& binary_operation) {
+  Extract(binary_operation.lhs());
+  Extract(binary_operation.rhs());
+}
+
+}  // namespace internal
+}  // namespace zetasql_fuzzer

--- a/zetasql/fuzzing/protobuf/internal/parameter_value_map_extractor.cc
+++ b/zetasql/fuzzing/protobuf/internal/parameter_value_map_extractor.cc
@@ -37,7 +37,7 @@ void ParameterValueMapExtractor::Extract(const zetasql_expression_grammar::Expre
 }
 
 void ParameterValueMapExtractor::Extract(const parameter_grammar::Value& value) {
-  if (value.has_as_variable()) {
+  if (value.has_as_variable() && extract_type_ == value.as_variable().type()) {
     zetasql::Value extracted(LiteralValueExtractor::Extract(value.literal()));
     if (extracted.is_valid()) {
       builder_[value.as_variable().name()] = extracted;

--- a/zetasql/fuzzing/protobuf/internal/parameter_value_map_extractor.cc
+++ b/zetasql/fuzzing/protobuf/internal/parameter_value_map_extractor.cc
@@ -45,8 +45,7 @@ zetasql::Value Extract(const parameter_grammar::Literal& literal) {
     case Literal::kNumericLiteral:
       return Extract(literal.numeric_literal());
     default:
-      LOG(FATAL) << "Unhandled LiteralExpr to Value conversion at "
-                    "ParameterValueMapExtractor";
+      return ExtractDefault(literal);
   }
 }
 
@@ -61,15 +60,16 @@ zetasql::Value Extract(const parameter_grammar::IntegerLiteral& integer) {
     case IntegerLiteral::kUint64Literal:
       return zetasql::Value::Uint64(integer.uint64_literal());
     default:
-      LOG(FATAL) << "Unhandled IntegerLiteral to Value conversion at "
-                    "ParameterValueMapExtractor";
+      return ExtractDefault(integer);
   }
 }
 
 zetasql::Value Extract(const parameter_grammar::NumericLiteral& numeric) {
-  // TODO: Handle ValueOrDie
-  return zetasql::Value::Numeric(
-      zetasql::NumericValue::FromString(numeric.value()).ValueOrDie());
+  auto value(zetasql::NumericValue::FromString(numeric.value()));
+  if (value) {
+    return zetasql::Value::Numeric(value.value());
+  }
+  return zetasql::Value::Numeric((zetasql::NumericValue()));
 }
 
 zetasql::Value Extract(zetasql::TypeKind null_type) {

--- a/zetasql/fuzzing/protobuf/internal/parameter_value_map_extractor.cc
+++ b/zetasql/fuzzing/protobuf/internal/parameter_value_map_extractor.cc
@@ -16,89 +16,14 @@
 
 #include "zetasql/fuzzing/protobuf/internal/parameter_value_map_extractor.h"
 
-using parameter_grammar::Identifier;
-using parameter_grammar::IntegerLiteral;
-using parameter_grammar::Literal;
-using parameter_grammar::NumericLiteral;
-using parameter_grammar::Whitespace;
+#include "zetasql/fuzzing/protobuf/internal/literal_value_extractor.h"
+
 using zetasql_expression_grammar::BinaryOperation;
 using zetasql_expression_grammar::CompoundExpr;
 using zetasql_expression_grammar::Expression;
 
 namespace zetasql_fuzzer {
 namespace internal {
-
-namespace LiteralValueExtractor {
-
-zetasql::Value Extract(const parameter_grammar::Literal& literal) {
-  switch (literal.literal_oneof_case()) {
-    case Literal::kBoolLiteral:
-      return zetasql::Value::Bool(literal.bool_literal());
-    case Literal::kNullLiteral:
-      return Extract(literal.null_literal());
-    case Literal::kBytesLiteral:
-      return zetasql::Value::Bytes(literal.bytes_literal());
-    case Literal::kStringLiteral:
-      return zetasql::Value::StringValue(literal.string_literal());
-    case Literal::kIntegerLiteral:
-      return Extract(literal.integer_literal());
-    case Literal::kNumericLiteral:
-      return Extract(literal.numeric_literal());
-    default:
-      return ExtractDefault(literal);
-  }
-}
-
-zetasql::Value Extract(const parameter_grammar::IntegerLiteral& integer) {
-  switch (integer.integer_oneof_case()) {
-    case IntegerLiteral::kInt32Literal:
-      return zetasql::Value::Int32(integer.int32_literal());
-    case IntegerLiteral::kInt64Literal:
-      return zetasql::Value::Int64(integer.int64_literal());
-    case IntegerLiteral::kUint32Literal:
-      return zetasql::Value::Uint32(integer.uint32_literal());
-    case IntegerLiteral::kUint64Literal:
-      return zetasql::Value::Uint64(integer.uint64_literal());
-    default:
-      return ExtractDefault(integer);
-  }
-}
-
-zetasql::Value Extract(const parameter_grammar::NumericLiteral& numeric) {
-  auto value(zetasql::NumericValue::FromString(numeric.value()));
-  if (value) {
-    return zetasql::Value::Numeric(value.value());
-  }
-  return zetasql::Value::Numeric((zetasql::NumericValue()));
-}
-
-zetasql::Value Extract(zetasql::TypeKind null_type) {
-  switch (null_type) {
-    case zetasql::TYPE_INT32:
-    case zetasql::TYPE_INT64:
-    case zetasql::TYPE_UINT32:
-    case zetasql::TYPE_UINT64:
-    case zetasql::TYPE_BOOL:
-    case zetasql::TYPE_FLOAT:
-    case zetasql::TYPE_DOUBLE:
-    case zetasql::TYPE_STRING:
-    case zetasql::TYPE_BYTES:
-    case zetasql::TYPE_TIMESTAMP:
-    case zetasql::TYPE_DATE:
-    case zetasql::TYPE_TIME:
-    case zetasql::TYPE_DATETIME:
-    case zetasql::TYPE_GEOGRAPHY:
-    case zetasql::TYPE_NUMERIC:
-    case zetasql::TYPE_BIGNUMERIC:
-      return zetasql::Value::Null(
-          zetasql::types::TypeFromSimpleTypeKind(null_type));
-    // Treat all other types as invalid type
-    default:
-      return zetasql::Value::Invalid();
-  }
-}
-
-}  // namespace LiteralValueExtractor
 
 void ParameterValueMapExtractor::Extract(const zetasql_expression_grammar::Expression& expr) {
   switch (expr.expr_oneof_case()) {

--- a/zetasql/fuzzing/protobuf/internal/parameter_value_map_extractor.h
+++ b/zetasql/fuzzing/protobuf/internal/parameter_value_map_extractor.h
@@ -25,6 +25,17 @@ namespace internal {
 
 class ParameterValueMapExtractor : public ProtoExprExtractor<zetasql::ParameterValueMap> {
  public:
+  ParameterValueMapExtractor() = delete;
+  ParameterValueMapExtractor(const ParameterValueMapExtractor&) = default;
+  ParameterValueMapExtractor& operator=(const ParameterValueMapExtractor&) = default;
+  ParameterValueMapExtractor(ParameterValueMapExtractor&&) = default;
+  ParameterValueMapExtractor& operator=(ParameterValueMapExtractor&&) = default;
+
+  ParameterValueMapExtractor(parameter_grammar::Identifier::Type type)
+      : extract_type_(type) {}
+
+  virtual ~ParameterValueMapExtractor() = default;
+
   void Extract(const parameter_grammar::Value& value) override;
   void Extract(const zetasql_expression_grammar::Expression& expr) override;
   void Extract(const zetasql_expression_grammar::CompoundExpr& comp_expr) override;
@@ -33,6 +44,7 @@ class ParameterValueMapExtractor : public ProtoExprExtractor<zetasql::ParameterV
 
  private:
   zetasql::ParameterValueMap builder_;
+  parameter_grammar::Identifier::Type extract_type_;
 };
 
 }  // namespace internal

--- a/zetasql/fuzzing/protobuf/internal/parameter_value_map_extractor.h
+++ b/zetasql/fuzzing/protobuf/internal/parameter_value_map_extractor.h
@@ -1,0 +1,52 @@
+//
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef ZETASQL_FUZZING_PARAMETER_VALUE_MAP_EXTRACTOR_H
+#define ZETASQL_FUZZING_PARAMETER_VALUE_MAP_EXTRACTOR_H
+
+#include "zetasql/fuzzing/protobuf/internal/syntax_tree_visitor.h"
+#include "zetasql/public/evaluator_base.h"
+#include "zetasql/public/value.h"
+
+namespace zetasql_fuzzer {
+namespace internal {
+
+namespace LiteralValueExtractor {
+zetasql::Value Extract(const parameter_grammar::Literal& literal);
+zetasql::Value Extract(const parameter_grammar::IntegerLiteral& integer);
+zetasql::Value Extract(const parameter_grammar::NumericLiteral& numeric);
+zetasql::Value Extract(zetasql::TypeKind null_type);
+}  // namespace LiteralValueExtractor
+
+class ParameterValueMapExtractor : public ProtoExprExtractor<zetasql::ParameterValueMap> {
+ public:
+
+  void Extract(const parameter_grammar::Value& value) override;
+
+  void Extract(const zetasql_expression_grammar::Expression& expr) override;
+  void Extract(const zetasql_expression_grammar::CompoundExpr& comp_expr) override;
+  void Extract(const zetasql_expression_grammar::BinaryOperation& binary_operation) override;
+
+  inline const zetasql::ParameterValueMap& Data() override { return builder_; }
+
+ private:
+  zetasql::ParameterValueMap builder_;
+};
+
+}  // namespace internal
+}  // namespace zetasql_fuzzer
+
+#endif  // ZETASQL_FUZZING_PARAMETER_VALUE_MAP_EXTRACTOR_H

--- a/zetasql/fuzzing/protobuf/internal/parameter_value_map_extractor.h
+++ b/zetasql/fuzzing/protobuf/internal/parameter_value_map_extractor.h
@@ -29,17 +29,18 @@ zetasql::Value Extract(const parameter_grammar::Literal& literal);
 zetasql::Value Extract(const parameter_grammar::IntegerLiteral& integer);
 zetasql::Value Extract(const parameter_grammar::NumericLiteral& numeric);
 zetasql::Value Extract(zetasql::TypeKind null_type);
+template <typename T>
+inline zetasql::Value ExtractDefault(const T& literal) {
+  return zetasql::Value::Bytes(literal.default_value().content());
+}
 }  // namespace LiteralValueExtractor
 
 class ParameterValueMapExtractor : public ProtoExprExtractor<zetasql::ParameterValueMap> {
  public:
-
   void Extract(const parameter_grammar::Value& value) override;
-
   void Extract(const zetasql_expression_grammar::Expression& expr) override;
   void Extract(const zetasql_expression_grammar::CompoundExpr& comp_expr) override;
   void Extract(const zetasql_expression_grammar::BinaryOperation& binary_operation) override;
-
   inline const zetasql::ParameterValueMap& Data() override { return builder_; }
 
  private:

--- a/zetasql/fuzzing/protobuf/internal/parameter_value_map_extractor.h
+++ b/zetasql/fuzzing/protobuf/internal/parameter_value_map_extractor.h
@@ -19,21 +19,9 @@
 
 #include "zetasql/fuzzing/protobuf/internal/syntax_tree_visitor.h"
 #include "zetasql/public/evaluator_base.h"
-#include "zetasql/public/value.h"
 
 namespace zetasql_fuzzer {
 namespace internal {
-
-namespace LiteralValueExtractor {
-zetasql::Value Extract(const parameter_grammar::Literal& literal);
-zetasql::Value Extract(const parameter_grammar::IntegerLiteral& integer);
-zetasql::Value Extract(const parameter_grammar::NumericLiteral& numeric);
-zetasql::Value Extract(zetasql::TypeKind null_type);
-template <typename T>
-inline zetasql::Value ExtractDefault(const T& literal) {
-  return zetasql::Value::Bytes(literal.default_value().content());
-}
-}  // namespace LiteralValueExtractor
 
 class ParameterValueMapExtractor : public ProtoExprExtractor<zetasql::ParameterValueMap> {
  public:

--- a/zetasql/fuzzing/protobuf/internal/parameter_value_map_extractor_test.cc
+++ b/zetasql/fuzzing/protobuf/internal/parameter_value_map_extractor_test.cc
@@ -79,45 +79,36 @@ INSTANTIATE_TEST_SUITE_P(
       std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_PROTO), zetasql::Value())
     ));
 
-// TODO: Handle default value
+template <typename LiteralType>
+ExtractLiteralCallback ExtractableEmptyLiteral() {
+  return []() {
+    return internal::LiteralValueExtractor::Extract((LiteralType()));
+  };
+}
 
-// template <typename ExprType>
-// ExtractLiteralCallback ExtractableEmptyExpression() {
-//   return []() {
-//     ExprType expression;
-//     return internal::LiteralValueExtractor::Extract(expression);
-//   };
-// }
+INSTANTIATE_TEST_SUITE_P(
+    EmptyLiteralTest, LiteralValueExtractorTest,
+    ::testing::Combine(
+        ::testing::Values(ExtractableEmptyLiteral<Literal>(),
+                          ExtractableEmptyLiteral<IntegerLiteral>()),
+        ::testing::Values(zetasql::Value::Bytes(""))));
 
-// INSTANTIATE_TEST_SUITE_P(
-//     EmptyExpressionTest, LiteralValueExtractorTest,
-//     ::testing::Combine(
-//         ::testing::Values(ExtractableEmptyExpression<Expression>(),
-//                           ExtractableEmptyExpression<Literal>(),
-//                           ExtractableEmptyExpression<IntegerLiteral>(),
-//                           ExtractableEmptyExpression<CompoundExpr>()),
-//         ::testing::Values("")));
+template <typename LiteralType>
+ExtractLiteralCallback ExtractableDefaultValue(const std::string& value) {
+  return [value]() {
+    LiteralType literal;
+    literal.mutable_default_value()->set_content(value);
+    return internal::LiteralValueExtractor::Extract(literal);
+  };
+}
 
-// template <typename ExprType>
-// ExtractLiteralCallback ExtractableDefaultValue(const std::string& value) {
-//   return [value](ParameterValueMapExtractor& extractor) {
-//     ExprType expression;
-//     expression.mutable_default_value()->set_content(value);
-//     return internal::LiteralValueExtractor::Extract(expression);
-//   };
-// }
-
-// INSTANTIATE_TEST_SUITE_P(
-//     DefaultOneOfValueTest, LiteralValueExtractorTest,
-//     ::testing::Values(
-//         std::make_tuple(ExtractableDefaultValue<Expression>("default"),
-//                         "default"),
-//         std::make_tuple(ExtractableDefaultValue<Literal>("default_lit"),
-//                         "default_lit"),
-//         std::make_tuple(ExtractableDefaultValue<IntegerLiteral>("default_int"),
-//                         "default_int"),
-//         std::make_tuple(ExtractableDefaultValue<CompoundExpr>("default_expr"),
-//                         "default_expr")));
+INSTANTIATE_TEST_SUITE_P(
+    DefaultOneOfValueTest, LiteralValueExtractorTest,
+    ::testing::Values(
+        std::make_tuple(ExtractableDefaultValue<Literal>("default_lit"),
+                        zetasql::Value::Bytes("default_lit")),
+        std::make_tuple(ExtractableDefaultValue<IntegerLiteral>("default_int"),
+                        zetasql::Value::Bytes("default_int"))));
 
 ExtractLiteralCallback ExtractableStringLiteral(
     const std::string& value) {
@@ -211,7 +202,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(
       std::make_tuple(ExtractableNumeric("12345"), zetasql::Value::Numeric(zetasql::NumericValue(12345))),
       std::make_tuple(ExtractableNumeric("123.45"), zetasql::Value::Numeric(zetasql::NumericValue::FromString("123.45").ValueOrDie())),
-      std::make_tuple(ExtractableNumeric("1234sdf"), zetasql::Value())
+      std::make_tuple(ExtractableNumeric("1234sdf"), zetasql::Value::Numeric(zetasql::NumericValue(0)))
     ));
 
 TEST(ParameterValueMapTest, NonvariableTest) {

--- a/zetasql/fuzzing/protobuf/internal/parameter_value_map_extractor_test.cc
+++ b/zetasql/fuzzing/protobuf/internal/parameter_value_map_extractor_test.cc
@@ -21,12 +21,7 @@
 #include <tuple>
 
 #include "gtest/gtest.h"
-#include "zetasql/public/numeric_value.h"
 
-using parameter_grammar::IntegerLiteral;
-using parameter_grammar::Literal;
-using parameter_grammar::NumericLiteral;
-using parameter_grammar::Whitespace;
 using zetasql_expression_grammar::BinaryOperation;
 using zetasql_expression_grammar::CompoundExpr;
 using zetasql_expression_grammar::Expression;
@@ -35,176 +30,6 @@ using zetasql_fuzzer::internal::ParameterValueMapExtractor;
 namespace zetasql_fuzzer {
 namespace {
   
-using ExtractLiteralCallback = std::function<zetasql::Value(void)>;
-class LiteralValueExtractorTest
-    : public ::testing::TestWithParam<
-          std::tuple<ExtractLiteralCallback, zetasql::Value>> {};
-
-TEST_P(LiteralValueExtractorTest, ExtractTest) {
-  EXPECT_EQ(std::get<0>(GetParam())(), std::get<1>(GetParam()));
-}
-
-ExtractLiteralCallback ExtractableNullLiteral(zetasql::TypeKind kind) {
-  return [kind]() {
-    Literal literal;
-    literal.set_null_literal(kind);
-    return internal::LiteralValueExtractor::Extract(literal);
-  };
-}
-
-INSTANTIATE_TEST_SUITE_P(
-    NullLiteralValueTest, LiteralValueExtractorTest,
-    ::testing::Values(
-      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_INT32), zetasql::Value::NullInt32()),
-      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_INT64), zetasql::Value::NullInt64()),
-      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_UINT32), zetasql::Value::NullUint32()),
-      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_UINT64), zetasql::Value::NullUint64()),
-      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_BOOL), zetasql::Value::NullBool()),
-      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_FLOAT), zetasql::Value::NullFloat()),
-      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_DOUBLE), zetasql::Value::NullDouble()),
-      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_STRING), zetasql::Value::NullString()),
-      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_BYTES), zetasql::Value::NullBytes()),
-      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_DATE), zetasql::Value::NullDate()),
-      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_TIMESTAMP), zetasql::Value::NullTimestamp()),
-      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_TIME), zetasql::Value::NullTime()),
-      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_DATETIME), zetasql::Value::NullDatetime()),
-      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_GEOGRAPHY), zetasql::Value::NullGeography()),
-      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_NUMERIC), zetasql::Value::NullNumeric()),
-      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_BIGNUMERIC), zetasql::Value::NullBigNumeric()),
-      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::__TypeKind__switch_must_have_a_default__), zetasql::Value()),
-      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_UNKNOWN), zetasql::Value()),
-      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_ENUM), zetasql::Value()),
-      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_ARRAY), zetasql::Value()),
-      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_STRUCT), zetasql::Value()),
-      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_PROTO), zetasql::Value())
-    ));
-
-template <typename LiteralType>
-ExtractLiteralCallback ExtractableEmptyLiteral() {
-  return []() {
-    return internal::LiteralValueExtractor::Extract((LiteralType()));
-  };
-}
-
-INSTANTIATE_TEST_SUITE_P(
-    EmptyLiteralTest, LiteralValueExtractorTest,
-    ::testing::Combine(
-        ::testing::Values(ExtractableEmptyLiteral<Literal>(),
-                          ExtractableEmptyLiteral<IntegerLiteral>()),
-        ::testing::Values(zetasql::Value::Bytes(""))));
-
-template <typename LiteralType>
-ExtractLiteralCallback ExtractableDefaultValue(const std::string& value) {
-  return [value]() {
-    LiteralType literal;
-    literal.mutable_default_value()->set_content(value);
-    return internal::LiteralValueExtractor::Extract(literal);
-  };
-}
-
-INSTANTIATE_TEST_SUITE_P(
-    DefaultOneOfValueTest, LiteralValueExtractorTest,
-    ::testing::Values(
-        std::make_tuple(ExtractableDefaultValue<Literal>("default_lit"),
-                        zetasql::Value::Bytes("default_lit")),
-        std::make_tuple(ExtractableDefaultValue<IntegerLiteral>("default_int"),
-                        zetasql::Value::Bytes("default_int"))));
-
-ExtractLiteralCallback ExtractableStringLiteral(
-    const std::string& value) {
-  return [value]() {
-    Literal expr;
-    expr.set_string_literal(value);
-    return internal::LiteralValueExtractor::Extract(expr);
-  };
-}
-
-INSTANTIATE_TEST_SUITE_P(
-    StringLiteralTest, LiteralValueExtractorTest,
-    ::testing::Values(std::make_tuple(ExtractableStringLiteral(""),
-                                      zetasql::Value::StringValue("")),
-                      std::make_tuple(ExtractableStringLiteral("tEsT"),
-                                      zetasql::Value::StringValue("tEsT"))));
-
-ExtractLiteralCallback ExtractableBytesLiteral(
-    const std::string& value) {
-  return [value]() {
-    Literal expr;
-    expr.set_bytes_literal(value);
-    return internal::LiteralValueExtractor::Extract(expr);
-  };
-}
-
-INSTANTIATE_TEST_SUITE_P(
-    BytesLiteralTest, LiteralValueExtractorTest,
-    ::testing::Values(
-        std::make_tuple(ExtractableBytesLiteral(""), zetasql::Value::Bytes("")),
-        std::make_tuple(ExtractableBytesLiteral("TeSt"), zetasql::Value::Bytes("TeSt")),
-        std::make_tuple(ExtractableBytesLiteral("\x01\x02"), zetasql::Value::Bytes("\x01\x02"))));
-
-template <IntegerLiteral::IntegerOneofCase IntegerType, typename T>
-ExtractLiteralCallback ExtractableIntegerLiteral(T value) {
-  return [value]() {
-    IntegerLiteral expression;
-    switch (IntegerType) {
-      case IntegerLiteral::kInt32Literal:
-        expression.set_int32_literal(value);
-        break;
-      case IntegerLiteral::kUint32Literal:
-        expression.set_uint32_literal(value);
-        break;
-      case IntegerLiteral::kInt64Literal:
-        expression.set_int64_literal(value);
-        break;
-      case IntegerLiteral::kUint64Literal:
-        expression.set_uint64_literal(value);
-        break;
-      default:
-        assert(false && "IntegerType for IntegerLiteralTest is wrongly set up");
-    }
-    return internal::LiteralValueExtractor::Extract(expression);
-  };
-}
-
-INSTANTIATE_TEST_SUITE_P(
-  IntegerLiteralTest, LiteralValueExtractorTest,
-  ::testing::Values(
-    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kInt32Literal>(1), zetasql::Value::Int32(1)),
-    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kInt32Literal>(0), zetasql::Value::Int32(0)),
-    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kInt32Literal>(google::protobuf::kint32max), zetasql::Value::Int32(2147483647)),
-    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kInt32Literal>(google::protobuf::kint32min), zetasql::Value::Int32(-2147483648)),
-
-    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kUint32Literal>(1), zetasql::Value::Uint32(1)),
-    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kUint32Literal>(0), zetasql::Value::Uint32(0)),
-    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kUint32Literal>(google::protobuf::kuint32max), zetasql::Value::Uint32(4294967295)),
-
-    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kInt64Literal>(1), zetasql::Value::Int64(1)),
-    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kInt64Literal>(0), zetasql::Value::Int64(0)),
-    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kInt64Literal>(google::protobuf::kint64max), zetasql::Value::Int64(9223372036854775807)),
-    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kInt64Literal>(google::protobuf::kint64min), zetasql::Value::Int64(-9223372036854775808)),
-
-    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kUint64Literal>(1), zetasql::Value::Uint64(1)),
-    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kUint64Literal>(0), zetasql::Value::Uint64(0)),
-    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kUint64Literal>(google::protobuf::kuint64max), zetasql::Value::Uint64(18446744073709551615))
-  )
-);
-
-ExtractLiteralCallback ExtractableNumeric(const std::string& value) {
-  return [value]() {
-    NumericLiteral expression;
-    expression.set_value(value);
-    return internal::LiteralValueExtractor::Extract(expression);
-  };
-}
-
-INSTANTIATE_TEST_SUITE_P(
-    NumericLiteralTest, LiteralValueExtractorTest,
-    ::testing::Values(
-      std::make_tuple(ExtractableNumeric("12345"), zetasql::Value::Numeric(zetasql::NumericValue(12345))),
-      std::make_tuple(ExtractableNumeric("123.45"), zetasql::Value::Numeric(zetasql::NumericValue::FromString("123.45").ValueOrDie())),
-      std::make_tuple(ExtractableNumeric("1234sdf"), zetasql::Value::Numeric(zetasql::NumericValue(0)))
-    ));
-
 TEST(ParameterValueMapTest, NonvariableTest) {
   parameter_grammar::Value value;
   value.clear_as_variable();
@@ -232,9 +57,7 @@ TEST(ParameterValueMapTest, BinaryExprTest) {
   binary.mutable_lhs()->mutable_value()->mutable_as_variable()->set_name("lhs");
   binary.mutable_lhs()->mutable_value()->mutable_literal()->set_bytes_literal(
       "TeSt");
-  binary.mutable_left_pad()->set_space(Whitespace::TAB);
   binary.set_op(BinaryOperation::PLUS);
-  binary.mutable_right_pad()->set_space(Whitespace::NEWLINE);
   binary.mutable_rhs()
       ->mutable_value()
       ->mutable_literal()
@@ -249,7 +72,7 @@ TEST(ParameterValueMapTest, BinaryExprTest) {
                                          {"rhs", zetasql::Value::Int32(1)}})));
 }
 
-TEST_F(LiteralValueExtractorTest, CompoundExprTest) {
+TEST(ParameterValueMapTest, CompoundExprTest) {
   Expression expr;
   expr.mutable_expr()->mutable_binary_operation()
     ->set_op(BinaryOperation::MULTIPLY);
@@ -307,7 +130,7 @@ TEST_F(LiteralValueExtractorTest, CompoundExprTest) {
   EXPECT_EQ(extractor.Data(), result);
 }
 
-TEST_F(LiteralValueExtractorTest, IncrementalTest) {
+TEST(ParameterValueMapTest, IncrementalTest) {
   Expression expr;
   ParameterValueMapExtractor extractor;
 

--- a/zetasql/fuzzing/protobuf/internal/parameter_value_map_extractor_test.cc
+++ b/zetasql/fuzzing/protobuf/internal/parameter_value_map_extractor_test.cc
@@ -1,0 +1,343 @@
+//
+// Copyright 2020 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "zetasql/fuzzing/protobuf/internal/parameter_value_map_extractor.h"
+
+#include <memory>
+#include <string>
+#include <tuple>
+
+#include "gtest/gtest.h"
+#include "zetasql/public/numeric_value.h"
+
+using parameter_grammar::IntegerLiteral;
+using parameter_grammar::Literal;
+using parameter_grammar::NumericLiteral;
+using parameter_grammar::Whitespace;
+using zetasql_expression_grammar::BinaryOperation;
+using zetasql_expression_grammar::CompoundExpr;
+using zetasql_expression_grammar::Expression;
+using zetasql_fuzzer::internal::ParameterValueMapExtractor;
+
+namespace zetasql_fuzzer {
+namespace {
+  
+using ExtractLiteralCallback = std::function<zetasql::Value(void)>;
+class LiteralValueExtractorTest
+    : public ::testing::TestWithParam<
+          std::tuple<ExtractLiteralCallback, zetasql::Value>> {};
+
+TEST_P(LiteralValueExtractorTest, ExtractTest) {
+  EXPECT_EQ(std::get<0>(GetParam())(), std::get<1>(GetParam()));
+}
+
+ExtractLiteralCallback ExtractableNullLiteral(zetasql::TypeKind kind) {
+  return [kind]() {
+    Literal literal;
+    literal.set_null_literal(kind);
+    return internal::LiteralValueExtractor::Extract(literal);
+  };
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    NullLiteralValueTest, LiteralValueExtractorTest,
+    ::testing::Values(
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_INT32), zetasql::Value::NullInt32()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_INT64), zetasql::Value::NullInt64()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_UINT32), zetasql::Value::NullUint32()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_UINT64), zetasql::Value::NullUint64()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_BOOL), zetasql::Value::NullBool()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_FLOAT), zetasql::Value::NullFloat()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_DOUBLE), zetasql::Value::NullDouble()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_STRING), zetasql::Value::NullString()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_BYTES), zetasql::Value::NullBytes()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_DATE), zetasql::Value::NullDate()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_TIMESTAMP), zetasql::Value::NullTimestamp()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_TIME), zetasql::Value::NullTime()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_DATETIME), zetasql::Value::NullDatetime()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_GEOGRAPHY), zetasql::Value::NullGeography()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_NUMERIC), zetasql::Value::NullNumeric()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_BIGNUMERIC), zetasql::Value::NullBigNumeric()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::__TypeKind__switch_must_have_a_default__), zetasql::Value()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_UNKNOWN), zetasql::Value()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_ENUM), zetasql::Value()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_ARRAY), zetasql::Value()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_STRUCT), zetasql::Value()),
+      std::make_tuple(ExtractableNullLiteral(zetasql::TypeKind::TYPE_PROTO), zetasql::Value())
+    ));
+
+// TODO: Handle default value
+
+// template <typename ExprType>
+// ExtractLiteralCallback ExtractableEmptyExpression() {
+//   return []() {
+//     ExprType expression;
+//     return internal::LiteralValueExtractor::Extract(expression);
+//   };
+// }
+
+// INSTANTIATE_TEST_SUITE_P(
+//     EmptyExpressionTest, LiteralValueExtractorTest,
+//     ::testing::Combine(
+//         ::testing::Values(ExtractableEmptyExpression<Expression>(),
+//                           ExtractableEmptyExpression<Literal>(),
+//                           ExtractableEmptyExpression<IntegerLiteral>(),
+//                           ExtractableEmptyExpression<CompoundExpr>()),
+//         ::testing::Values("")));
+
+// template <typename ExprType>
+// ExtractLiteralCallback ExtractableDefaultValue(const std::string& value) {
+//   return [value](ParameterValueMapExtractor& extractor) {
+//     ExprType expression;
+//     expression.mutable_default_value()->set_content(value);
+//     return internal::LiteralValueExtractor::Extract(expression);
+//   };
+// }
+
+// INSTANTIATE_TEST_SUITE_P(
+//     DefaultOneOfValueTest, LiteralValueExtractorTest,
+//     ::testing::Values(
+//         std::make_tuple(ExtractableDefaultValue<Expression>("default"),
+//                         "default"),
+//         std::make_tuple(ExtractableDefaultValue<Literal>("default_lit"),
+//                         "default_lit"),
+//         std::make_tuple(ExtractableDefaultValue<IntegerLiteral>("default_int"),
+//                         "default_int"),
+//         std::make_tuple(ExtractableDefaultValue<CompoundExpr>("default_expr"),
+//                         "default_expr")));
+
+ExtractLiteralCallback ExtractableStringLiteral(
+    const std::string& value) {
+  return [value]() {
+    Literal expr;
+    expr.set_string_literal(value);
+    return internal::LiteralValueExtractor::Extract(expr);
+  };
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    StringLiteralTest, LiteralValueExtractorTest,
+    ::testing::Values(std::make_tuple(ExtractableStringLiteral(""),
+                                      zetasql::Value::StringValue("")),
+                      std::make_tuple(ExtractableStringLiteral("tEsT"),
+                                      zetasql::Value::StringValue("tEsT"))));
+
+ExtractLiteralCallback ExtractableBytesLiteral(
+    const std::string& value) {
+  return [value]() {
+    Literal expr;
+    expr.set_bytes_literal(value);
+    return internal::LiteralValueExtractor::Extract(expr);
+  };
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BytesLiteralTest, LiteralValueExtractorTest,
+    ::testing::Values(
+        std::make_tuple(ExtractableBytesLiteral(""), zetasql::Value::Bytes("")),
+        std::make_tuple(ExtractableBytesLiteral("TeSt"), zetasql::Value::Bytes("TeSt")),
+        std::make_tuple(ExtractableBytesLiteral("\x01\x02"), zetasql::Value::Bytes("\x01\x02"))));
+
+template <IntegerLiteral::IntegerOneofCase IntegerType, typename T>
+ExtractLiteralCallback ExtractableIntegerLiteral(T value) {
+  return [value]() {
+    IntegerLiteral expression;
+    switch (IntegerType) {
+      case IntegerLiteral::kInt32Literal:
+        expression.set_int32_literal(value);
+        break;
+      case IntegerLiteral::kUint32Literal:
+        expression.set_uint32_literal(value);
+        break;
+      case IntegerLiteral::kInt64Literal:
+        expression.set_int64_literal(value);
+        break;
+      case IntegerLiteral::kUint64Literal:
+        expression.set_uint64_literal(value);
+        break;
+      default:
+        assert(false && "IntegerType for IntegerLiteralTest is wrongly set up");
+    }
+    return internal::LiteralValueExtractor::Extract(expression);
+  };
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  IntegerLiteralTest, LiteralValueExtractorTest,
+  ::testing::Values(
+    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kInt32Literal>(1), zetasql::Value::Int32(1)),
+    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kInt32Literal>(0), zetasql::Value::Int32(0)),
+    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kInt32Literal>(google::protobuf::kint32max), zetasql::Value::Int32(2147483647)),
+    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kInt32Literal>(google::protobuf::kint32min), zetasql::Value::Int32(-2147483648)),
+
+    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kUint32Literal>(1), zetasql::Value::Uint32(1)),
+    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kUint32Literal>(0), zetasql::Value::Uint32(0)),
+    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kUint32Literal>(google::protobuf::kuint32max), zetasql::Value::Uint32(4294967295)),
+
+    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kInt64Literal>(1), zetasql::Value::Int64(1)),
+    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kInt64Literal>(0), zetasql::Value::Int64(0)),
+    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kInt64Literal>(google::protobuf::kint64max), zetasql::Value::Int64(9223372036854775807)),
+    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kInt64Literal>(google::protobuf::kint64min), zetasql::Value::Int64(-9223372036854775808)),
+
+    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kUint64Literal>(1), zetasql::Value::Uint64(1)),
+    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kUint64Literal>(0), zetasql::Value::Uint64(0)),
+    std::make_tuple(ExtractableIntegerLiteral<IntegerLiteral::kUint64Literal>(google::protobuf::kuint64max), zetasql::Value::Uint64(18446744073709551615))
+  )
+);
+
+ExtractLiteralCallback ExtractableNumeric(const std::string& value) {
+  return [value]() {
+    NumericLiteral expression;
+    expression.set_value(value);
+    return internal::LiteralValueExtractor::Extract(expression);
+  };
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    NumericLiteralTest, LiteralValueExtractorTest,
+    ::testing::Values(
+      std::make_tuple(ExtractableNumeric("12345"), zetasql::Value::Numeric(zetasql::NumericValue(12345))),
+      std::make_tuple(ExtractableNumeric("123.45"), zetasql::Value::Numeric(zetasql::NumericValue::FromString("123.45").ValueOrDie())),
+      std::make_tuple(ExtractableNumeric("1234sdf"), zetasql::Value())
+    ));
+
+TEST(ParameterValueMapTest, NonvariableTest) {
+  parameter_grammar::Value value;
+  value.clear_as_variable();
+  value.mutable_literal()->set_bytes_literal("test");
+
+  ParameterValueMapExtractor extractor;
+  extractor.Extract(value);
+  EXPECT_EQ(extractor.Data(), ((zetasql::ParameterValueMap())));
+}
+
+TEST(ParameterValueMapTest, VariableTest) {
+  parameter_grammar::Value value;
+  value.mutable_as_variable()->set_name("test_var");
+  value.mutable_literal()->set_bytes_literal("test");
+
+  ParameterValueMapExtractor extractor;
+  extractor.Extract(value);
+  EXPECT_EQ(extractor.Data(),
+            ((zetasql::ParameterValueMap{
+                {"test_var", zetasql::Value::Bytes("test")}})));
+}
+
+TEST(ParameterValueMapTest, BinaryExprTest) {
+  BinaryOperation binary;
+  binary.mutable_lhs()->mutable_value()->mutable_as_variable()->set_name("lhs");
+  binary.mutable_lhs()->mutable_value()->mutable_literal()->set_bytes_literal(
+      "TeSt");
+  binary.mutable_left_pad()->set_space(Whitespace::TAB);
+  binary.set_op(BinaryOperation::PLUS);
+  binary.mutable_right_pad()->set_space(Whitespace::NEWLINE);
+  binary.mutable_rhs()
+      ->mutable_value()
+      ->mutable_literal()
+      ->mutable_integer_literal()
+      ->set_int32_literal(1);
+  binary.mutable_rhs()->mutable_value()->mutable_as_variable()->set_name("rhs");
+
+  ParameterValueMapExtractor extractor;
+  extractor.Extract(binary);
+  EXPECT_EQ(extractor.Data(),
+            ((zetasql::ParameterValueMap{{"lhs", zetasql::Value::Bytes("TeSt")},
+                                         {"rhs", zetasql::Value::Int32(1)}})));
+}
+
+TEST_F(LiteralValueExtractorTest, CompoundExprTest) {
+  Expression expr;
+  expr.mutable_expr()->mutable_binary_operation()
+    ->set_op(BinaryOperation::MULTIPLY);
+  expr.mutable_expr()
+      ->mutable_binary_operation()
+      ->mutable_lhs()
+      ->mutable_value()
+      ->mutable_literal()
+      ->set_string_literal("tEsT");
+  expr.mutable_expr()
+      ->mutable_binary_operation()
+      ->mutable_lhs()
+      ->mutable_value()
+      ->mutable_as_variable()
+      ->set_name("var1");
+
+  auto subexpr = std::make_unique<Expression>();
+  subexpr->mutable_expr()->mutable_binary_operation()
+    ->set_op(BinaryOperation::MINUS);
+  subexpr->mutable_expr()
+      ->mutable_binary_operation()
+      ->mutable_lhs()
+      ->mutable_value()
+      ->mutable_literal()
+      ->mutable_integer_literal()
+      ->set_uint64_literal(google::protobuf::kuint64max);
+  subexpr->mutable_expr()
+      ->mutable_binary_operation()
+      ->mutable_lhs()
+      ->mutable_value()
+      ->mutable_as_variable()
+      ->set_name("var2");
+  subexpr->mutable_expr()
+      ->mutable_binary_operation()
+      ->mutable_rhs()
+      ->mutable_value()
+      ->mutable_literal()
+      ->mutable_integer_literal()
+      ->set_int32_literal(google::protobuf::kint32min);
+  subexpr->mutable_expr()
+      ->mutable_binary_operation()
+      ->mutable_rhs()
+      ->mutable_value()
+      ->mutable_as_variable()
+      ->set_name("var3");
+
+  expr.mutable_expr()->mutable_binary_operation()
+    ->set_allocated_rhs(subexpr.release()); 
+  ParameterValueMapExtractor extractor;
+  extractor.Extract(expr);
+  zetasql::ParameterValueMap result{
+      {"var1", zetasql::Value::StringValue("tEsT")},
+      {"var2", zetasql::Value::Uint64(google::protobuf::kuint64max)},
+      {"var3", zetasql::Value::Int32(google::protobuf::kint32min)}};
+  EXPECT_EQ(extractor.Data(), result);
+}
+
+TEST_F(LiteralValueExtractorTest, IncrementalTest) {
+  Expression expr;
+  ParameterValueMapExtractor extractor;
+
+  expr.mutable_value()
+      ->mutable_literal()
+      ->mutable_integer_literal()
+      ->set_int32_literal(1);
+  expr.mutable_value()->mutable_as_variable()->set_name("var1");
+  extractor.Extract(expr);
+
+  parameter_grammar::Value num_expr;
+  num_expr.mutable_as_variable()->set_name("var2");
+  num_expr.mutable_literal()->mutable_integer_literal()->set_int32_literal(1234);
+  extractor.Extract(num_expr);
+
+  zetasql::ParameterValueMap result{
+      {"var1", zetasql::Value::Int32(1)},
+      {"var2", zetasql::Value::Int32(1234)},
+  };
+  EXPECT_EQ(extractor.Data(), result);
+}
+
+}  // namespace
+}  // namespace zetasql_fuzzer

--- a/zetasql/fuzzing/protobuf/internal/syntax_tree_visitor.h
+++ b/zetasql/fuzzing/protobuf/internal/syntax_tree_visitor.h
@@ -26,12 +26,14 @@ namespace internal {
 template <typename Result>
 class Extractor {
  public:
+  virtual ~Extractor() = default;
   virtual const Result& Data() = 0;
 };
 
 template <typename Result>
 class LiteralExtractor : public Extractor<Result> {
  public:
+  virtual ~LiteralExtractor() = default;
   virtual void Extract(const parameter_grammar::Literal& literal) = 0;
   virtual void Extract(const parameter_grammar::IntegerLiteral& integer) = 0;
   virtual void Extract(const parameter_grammar::NumericLiteral& numeric) = 0;
@@ -40,8 +42,9 @@ class LiteralExtractor : public Extractor<Result> {
 template <typename Result>
 class ProtoExprExtractor : public Extractor<Result> {
  public:
-  virtual void Extract(const parameter_grammar::Value& value) = 0;
+  virtual ~ProtoExprExtractor() = default;
 
+  virtual void Extract(const parameter_grammar::Value& value) = 0;
   virtual void Extract(const zetasql_expression_grammar::Expression& expr) = 0;
   virtual void Extract(const zetasql_expression_grammar::CompoundExpr& comp_expr) = 0;
   virtual void Extract(const zetasql_expression_grammar::BinaryOperation& binary_operation) = 0;

--- a/zetasql/fuzzing/protobuf/internal/syntax_tree_visitor.h
+++ b/zetasql/fuzzing/protobuf/internal/syntax_tree_visitor.h
@@ -1,0 +1,53 @@
+//
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef ZETASQL_FUZZING_SYNTAX_TREE_VISITOR_H
+#define ZETASQL_FUZZING_SYNTAX_TREE_VISITOR_H
+
+#include "zetasql/fuzzing/protobuf/parameter_grammar.pb.h"
+#include "zetasql/fuzzing/protobuf/zetasql_expression_grammar.pb.h"
+
+namespace zetasql_fuzzer {
+namespace internal {
+
+template <typename Result>
+class Extractor {
+ public:
+  virtual const Result& Data() = 0;
+};
+
+template <typename Result>
+class LiteralExtractor : public Extractor<Result> {
+ public:
+  virtual void Extract(const parameter_grammar::Literal& literal) = 0;
+  virtual void Extract(const parameter_grammar::IntegerLiteral& integer) = 0;
+  virtual void Extract(const parameter_grammar::NumericLiteral& numeric) = 0;
+};
+
+template <typename Result>
+class ProtoExprExtractor : public Extractor<Result> {
+ public:
+  virtual void Extract(const parameter_grammar::Value& value) = 0;
+
+  virtual void Extract(const zetasql_expression_grammar::Expression& expr) = 0;
+  virtual void Extract(const zetasql_expression_grammar::CompoundExpr& comp_expr) = 0;
+  virtual void Extract(const zetasql_expression_grammar::BinaryOperation& binary_operation) = 0;
+};
+
+}  // namespace internal
+}  // namespace zetasql_fuzzer
+
+#endif  // ZETASQL_FUZZING_SYNTAX_TREE_VISITOR_H

--- a/zetasql/fuzzing/protobuf/parameter_grammar.proto
+++ b/zetasql/fuzzing/protobuf/parameter_grammar.proto
@@ -16,6 +16,8 @@
 
 syntax = "proto2";
 
+import "zetasql/public/type.proto";
+
 package parameter_grammar;
 
 message Whitespace {
@@ -31,4 +33,45 @@ message Whitespace {
 
 message Default {
     required bytes content = 1;
+}
+
+message Identifier {
+    enum Type {
+        COLUMN = 0;
+        PARAMETER = 1;
+    }
+    required bytes name = 1;
+    required Type type = 2;
+}
+
+message Value {
+    required Literal literal = 1;
+    optional Identifier as_variable = 2;
+}
+
+message Literal {
+    oneof literal_oneof {
+        zetasql.TypeKind null_literal = 1;
+        bool bool_literal = 2;
+        string string_literal = 3;
+        bytes bytes_literal = 4;
+        IntegerLiteral integer_literal = 5;
+        NumericLiteral numeric_literal = 6;
+    }
+    required Default default_value = 7;
+}
+
+message IntegerLiteral {
+    oneof integer_oneof {
+        int32 int32_literal = 1;
+        uint32 uint32_literal = 2;
+        int64 int64_literal = 3;
+        uint64 uint64_literal = 4;
+    }
+    required Default default_value = 5;
+}
+
+// TODO: Support high precision value representation
+message NumericLiteral {
+    required bytes value = 1;
 }

--- a/zetasql/fuzzing/protobuf/zetasql_expression_grammar.proto
+++ b/zetasql/fuzzing/protobuf/zetasql_expression_grammar.proto
@@ -22,43 +22,13 @@ package zetasql_expression_grammar;
 
 message Expression {
     oneof expr_oneof {
-        LiteralExpr literal = 1;
+        parameter_grammar.Value value = 1;
         CompoundExpr expr = 2;
     }
     required parameter_grammar.Default default_value = 3;
     required bool parenthesized = 4;
     optional parameter_grammar.Whitespace leading_pad = 5;
     optional parameter_grammar.Whitespace trailing_pad = 6;
-}
-
-message LiteralExpr {
-    enum SpecialValue {
-        V_NULL = 0; // variable 'NULL' will be translated to NULL in C, causing failure
-    }
-    oneof literal_oneof {
-        SpecialValue special_literal = 1;
-        bool bool_literal = 2;
-        string string_literal = 3;
-        bytes bytes_literal = 4;
-        IntegerLiteral integer_literal = 5;
-        NumericLiteral numeric_literal = 6;
-    }
-    required parameter_grammar.Default default_value = 7;
-}
-
-message IntegerLiteral {
-    oneof integer_oneof {
-        int32 int32_literal = 1;
-        uint32 uint32_literal = 2;
-        int64 int64_literal = 3;
-        uint64 uint64_literal = 4;
-    }
-    required parameter_grammar.Default default_value = 5;
-}
-
-// TODO: Support high precision value representation
-message NumericLiteral {
-    required bytes value = 1;
 }
 
 message CompoundExpr {

--- a/zetasql/fuzzing/protobuf/zetasql_expression_proto_to_string.cc
+++ b/zetasql/fuzzing/protobuf/zetasql_expression_proto_to_string.cc
@@ -17,12 +17,13 @@
 #include <string>
 
 #include "absl/strings/str_cat.h"
+#include "zetasql/fuzzing/protobuf/parameter_grammar.pb.h"
 #include "zetasql/fuzzing/protobuf/zetasql_expression_grammar.pb.h"
 
 using zetasql_expression_grammar::Expression;
-using zetasql_expression_grammar::LiteralExpr;
-using zetasql_expression_grammar::IntegerLiteral;
-using zetasql_expression_grammar::NumericLiteral;
+using parameter_grammar::Literal;
+using parameter_grammar::IntegerLiteral;
+using parameter_grammar::NumericLiteral;
 using zetasql_expression_grammar::CompoundExpr;
 using zetasql_expression_grammar::BinaryOperation;
 
@@ -33,7 +34,7 @@ namespace zetasql_fuzzer {
 // Forward declaration
 TO_STRING(Expression, expr);
 
-TO_STRING(LiteralExpr, lit_expr);
+TO_STRING(Literal, lit_expr);
 TO_STRING(IntegerLiteral, integer);
 TO_STRING(NumericLiteral, numeric);
 
@@ -57,8 +58,8 @@ inline std::string Padded(const std::string& s) {
 TO_STRING(Expression, expr) {
   using ExprType = Expression::ExprOneofCase;
   switch (expr.expr_oneof_case()) {
-    case ExprType::kLiteral:
-      return LiteralExprToString(expr.literal());
+    case ExprType::kValue:
+      return LiteralToString(expr.value().literal());
     case ExprType::kExpr:
       return CompoundExprToString(expr.expr());
     default:
@@ -66,16 +67,11 @@ TO_STRING(Expression, expr) {
   }
 }
 
-TO_STRING(LiteralExpr, literal) {
-  using LitExprType = LiteralExpr::LiteralOneofCase;
+TO_STRING(Literal, literal) {
+  using LitExprType = Literal::LiteralOneofCase;
   switch (literal.literal_oneof_case()) {
-    case LitExprType::kSpecialLiteral:
-      switch (literal.special_literal()) {
-        case LiteralExpr::V_NULL:
-          return "NULL";
-        default:
-          HandleUndefined("Undefined Special Literal");
-      }
+    case LitExprType::kNullLiteral:
+      return "NULL";
     case LitExprType::kBoolLiteral:
       return literal.bool_literal() ? "TRUE" : "FALSE";
     case LitExprType::kBytesLiteral:

--- a/zetasql/fuzzing/protobuf/zetasql_expression_proto_to_string_test.cc
+++ b/zetasql/fuzzing/protobuf/zetasql_expression_proto_to_string_test.cc
@@ -30,10 +30,10 @@ TEST(ProtoToStringTest, UninitializedOneOfExprTest) {
   Expression expr;
   EXPECT_EQ(ExpressionToString(expr), "0");
 
-  expr.mutable_literal();
+  expr.mutable_value()->mutable_literal();
   EXPECT_EQ(ExpressionToString(expr), "0");
 
-  expr.mutable_literal()->mutable_integer_literal();
+  expr.mutable_value()->mutable_literal()->mutable_integer_literal();
   EXPECT_EQ(ExpressionToString(expr), "0");
 
   expr.mutable_expr();
@@ -41,104 +41,103 @@ TEST(ProtoToStringTest, UninitializedOneOfExprTest) {
 }
 
 TEST(ProtoToStringTest, SpecialLiteralTest) {
-  using SpecialVal = zetasql_expression_grammar::LiteralExpr_SpecialValue;
   Expression expr;
-  expr.mutable_literal()
-    ->set_special_literal(SpecialVal::LiteralExpr_SpecialValue_V_NULL);
+  expr.mutable_value()->mutable_literal()
+    ->set_null_literal(zetasql::TYPE_BOOL);
   EXPECT_EQ(ExpressionToString(expr), "NULL");
 }
 
 TEST(ProtoToStringTest, BooleanLiteralTest) {
   Expression expr;
-  expr.mutable_literal()
+  expr.mutable_value()->mutable_literal()
     ->set_bool_literal(true);
   EXPECT_EQ(ExpressionToString(expr), "TRUE");
 
-  expr.mutable_literal()
+  expr.mutable_value()->mutable_literal()
     ->set_bool_literal(false);
   EXPECT_EQ(ExpressionToString(expr), "FALSE");
 }
 
 TEST(ProtoToStringTest, StringLiteralTest) {
   Expression expr;
-  expr.mutable_literal()->mutable_string_literal();
+  expr.mutable_value()->mutable_literal()->mutable_string_literal();
   EXPECT_EQ(ExpressionToString(expr), "");
 
-  expr.mutable_literal()
+  expr.mutable_value()->mutable_literal()
     ->set_string_literal("TeSt");
   EXPECT_EQ(ExpressionToString(expr), "TeSt");
 
-  expr.mutable_literal()
+  expr.mutable_value()->mutable_literal()
     ->set_string_literal("");
   EXPECT_EQ(ExpressionToString(expr), "");
 }
 
 TEST(ProtoToStringTest, BytesLiteralTest) {
   Expression expr;
-  expr.mutable_literal()->mutable_bytes_literal();
+  expr.mutable_value()->mutable_literal()->mutable_bytes_literal();
   EXPECT_EQ(ExpressionToString(expr), "");
 
-  expr.mutable_literal()
+  expr.mutable_value()->mutable_literal()
     ->set_bytes_literal("TeSt");
   EXPECT_EQ(ExpressionToString(expr), "TeSt");
 
-  expr.mutable_literal()
+  expr.mutable_value()->mutable_literal()
     ->set_string_literal("\x01\x02");
   EXPECT_EQ(ExpressionToString(expr), "\x01\x02");
 }
 
 TEST(ProtoToStringTest, IntegerLiteralTest) {
   Expression expr;
-  expr.mutable_literal()->mutable_integer_literal()
+  expr.mutable_value()->mutable_literal()->mutable_integer_literal()
     ->set_int32_literal(1);
   EXPECT_EQ(ExpressionToString(expr), "1");
-  expr.mutable_literal()->mutable_integer_literal()
+  expr.mutable_value()->mutable_literal()->mutable_integer_literal()
     ->set_int32_literal(0);
   EXPECT_EQ(ExpressionToString(expr), "0");
-  expr.mutable_literal()->mutable_integer_literal()
+  expr.mutable_value()->mutable_literal()->mutable_integer_literal()
     ->set_int32_literal(google::protobuf::kint32max);
 EXPECT_EQ(ExpressionToString(expr), "2147483647");
-  expr.mutable_literal()->mutable_integer_literal()
+  expr.mutable_value()->mutable_literal()->mutable_integer_literal()
     ->set_int32_literal(google::protobuf::kint32min);
   EXPECT_EQ(ExpressionToString(expr), "-2147483648");
 
-  expr.mutable_literal()->mutable_integer_literal()
+  expr.mutable_value()->mutable_literal()->mutable_integer_literal()
     ->set_uint32_literal(1);
   EXPECT_EQ(ExpressionToString(expr), "1");
-  expr.mutable_literal()->mutable_integer_literal()
+  expr.mutable_value()->mutable_literal()->mutable_integer_literal()
     ->set_uint32_literal(0);
   EXPECT_EQ(ExpressionToString(expr), "0");
-  expr.mutable_literal()->mutable_integer_literal()
+  expr.mutable_value()->mutable_literal()->mutable_integer_literal()
     ->set_uint32_literal(google::protobuf::kuint32max);
   EXPECT_EQ(ExpressionToString(expr), "4294967295");
 
-  expr.mutable_literal()->mutable_integer_literal()
+  expr.mutable_value()->mutable_literal()->mutable_integer_literal()
     ->set_int64_literal(1);
   EXPECT_EQ(ExpressionToString(expr), "1");
-  expr.mutable_literal()->mutable_integer_literal()
+  expr.mutable_value()->mutable_literal()->mutable_integer_literal()
     ->set_int64_literal(0);
   EXPECT_EQ(ExpressionToString(expr), "0");
-  expr.mutable_literal()->mutable_integer_literal()
+  expr.mutable_value()->mutable_literal()->mutable_integer_literal()
     ->set_int64_literal(google::protobuf::kint64max);
   EXPECT_EQ(ExpressionToString(expr), "9223372036854775807");
-  expr.mutable_literal()->mutable_integer_literal()
+  expr.mutable_value()->mutable_literal()->mutable_integer_literal()
     ->set_int64_literal(google::protobuf::kint64min);
   EXPECT_EQ(ExpressionToString(expr), "-9223372036854775808");
 
-  expr.mutable_literal()->mutable_integer_literal()
+  expr.mutable_value()->mutable_literal()->mutable_integer_literal()
     ->set_uint64_literal(1);
   EXPECT_EQ(ExpressionToString(expr), "1");
-  expr.mutable_literal()->mutable_integer_literal()
+  expr.mutable_value()->mutable_literal()->mutable_integer_literal()
     ->set_uint64_literal(0);
   EXPECT_EQ(ExpressionToString(expr), "0");
-  expr.mutable_literal()->mutable_integer_literal()
+  expr.mutable_value()->mutable_literal()->mutable_integer_literal()
     ->set_uint64_literal(google::protobuf::kuint64max);
   EXPECT_EQ(ExpressionToString(expr), "18446744073709551615");
 }
 
 TEST(ProtoToStringTest, NumericLiteralTest) {
   Expression expr;
-  expr.mutable_literal()->mutable_numeric_literal()
+  expr.mutable_value()->mutable_literal()->mutable_numeric_literal()
     ->set_value("\xff\xff\xff\xff");
   EXPECT_EQ(ExpressionToString(expr), "\xff\xff\xff\xff");
 }
@@ -149,26 +148,26 @@ TEST(ProtoToStringTest, CompoundExprTest) {
   expr.mutable_expr()->mutable_binary_operation()
     ->set_op(BinaryOperation::PLUS);
   expr.mutable_expr()->mutable_binary_operation()
-    ->mutable_lhs()->mutable_literal()->mutable_integer_literal()
+    ->mutable_lhs()->mutable_value()->mutable_literal()->mutable_integer_literal()
     ->set_uint32_literal(1);
   expr.mutable_expr()->mutable_binary_operation()
-    ->mutable_rhs()->mutable_literal()->mutable_integer_literal()
+    ->mutable_rhs()->mutable_value()->mutable_literal()->mutable_integer_literal()
     ->set_uint32_literal(1);
   EXPECT_EQ(ExpressionToString(expr), "1 + 1");
 
   expr.mutable_expr()->mutable_binary_operation()
     ->set_op(BinaryOperation::MULTIPLY);
   expr.mutable_expr()->mutable_binary_operation()
-    ->mutable_lhs()->mutable_literal()->set_string_literal("tEsT");
+    ->mutable_lhs()->mutable_value()->mutable_literal()->set_string_literal("tEsT");
 
   auto subexpr = std::make_unique<Expression>();
   subexpr->mutable_expr()->mutable_binary_operation()
     ->set_op(BinaryOperation::MINUS);
   subexpr->mutable_expr()->mutable_binary_operation()
-    ->mutable_lhs()->mutable_literal()->mutable_integer_literal()
+    ->mutable_lhs()->mutable_value()->mutable_literal()->mutable_integer_literal()
     ->set_uint64_literal(google::protobuf::kuint64max);
   subexpr->mutable_expr()->mutable_binary_operation()
-    ->mutable_rhs()->mutable_literal()->mutable_integer_literal()
+    ->mutable_rhs()->mutable_value()->mutable_literal()->mutable_integer_literal()
     ->set_int32_literal(google::protobuf::kint32min);
 
   expr.mutable_expr()->mutable_binary_operation()


### PR DESCRIPTION
Added ParameterValueMap extractor to extract SQL statement variables from protobuf schema.

**There are two TODOs in this PR**
- [x] Handle the invalid numeric value 
- [x] Handle default literal value