### PR TITLE
Create Documentation for ZetaSQL Fuzzing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This is a temporary fork of [ZetaSQL](https://www.github.com/google/zetasql)
 for experimenting with various structured fuzzing strategies.  The main
 documentation is present on the primary repository.
 
+## Documentation of ZetaSQL Fuzzing Library
+
+See [doc](https://github.com/googleinterns/zetasql-fuzzing/tree/master/zetasql/fuzzing)
+
 ## License
 
 [Apache License 2.0](LICENSE)

--- a/zetasql/fuzzing/README.md
+++ b/zetasql/fuzzing/README.md
@@ -18,7 +18,7 @@ The documentation also assumes that readers are comfortable working with [Bazel]
 
 Fuzzers defined in ZetaSQL project currently have a mixed usage of both native `libfuzzer` interface for primitive fuzzing, as well as Libprotobuf-mutator [(LPM)](https://github.com/google/fuzzing/blob/master/docs/structure-aware-fuzzing.md#protocol-buffers-as-intermediate-format) interface for structure aware fuzzing. Additionally, many fuzzers behave in fairly similar ways that they all extract some arguments from the test input and apply them to the tested API. FAIR library deconstructs general fuzzers into four components and helps increase code reuse through composition.
 
-Specifically, FAIR is short for 
+Specifically, FAIR is short for:
 
 - `zetasql_fuzzer::FuzzTarget`, an abstraction for any ZetaSQL APIs to be fuzzed. It encapsulates the logic of setting up calls to ZetaSQL APIs given correct arguments. During fuzzing, `zetasql_fuzzer::FuzzTarget` gets arguments for the API calls by visiting available `zetasql_fuzzer::Argument`s. `zetasql_fuzzer::FuzzTarget` is a Visitor to `zetasql_fuzzer::Argument`.
 - <a id='arg'>`zetasql_fuzzer::Argument`</a>, an abstraction for any value that is extracted from the fuzzing input of `InputType` in `zetasql_fuzzer::Run` routine, and is to be applied to some `zetasql_fuzzer::FuzzTarget` in a fuzzing test. It is a Visitable to `zetasql::FuzzTarget`.

--- a/zetasql/fuzzing/README.md
+++ b/zetasql/fuzzing/README.md
@@ -2,7 +2,7 @@
 
 ## Code Deprecation and Notes
 
-As part of the experimental code, `zetasql_expression_fuzzer.cc` has been replaced by `pipelined_expression_fuzzer.cc` but with FAIR library integration. `zetasql_expression_fuzzer.cc` and its dependencies existed only for existing bug reproduction. Future developer should model after `pipelined_expression_fuzzer.cc` for correct use of FAIR library.
+As part of the experimental code, `zetasql_expression_fuzzer.cc` has been replaced by `pipelined_expression_fuzzer.cc` but with FAIR library integration. `zetasql_expression_fuzzer.cc` and its dependencies exists only for existing bug reproduction. Future developer should model after `pipelined_expression_fuzzer.cc` for correct use of FAIR library.
 
 The current Bazel build dependency isn't exactly at its finest, and combining with `fuzzer_macro.h`, every fuzzer will be compiled with `libprotobuf-mutator` dependency whether it's defined as a `cc_proto_fuzzer` or `cc_fuzzer`. Effort to separate the dependency is welcomed.
 

--- a/zetasql/fuzzing/README.md
+++ b/zetasql/fuzzing/README.md
@@ -146,11 +146,11 @@ class SQLStringArg : public TypedArg<std::string> {
 
 `Argument` is implemented as a type-erased container, and combined with Visitor pattern, `Argument` yields great flexibility for both `FuzzTarget` and `Extractor`. `Extractor` can be as simple as `std::make_unique<SQLStringArg, const std::string&>` in the case of `simple_evaluator_fuzzer.cc`, or as complicated as `GetParam<As::PARAMETERS>` in `piplined_expression_fuzzer.cc`. For LPM based structure aware fuzzer, we refer readers to `protobuf/argument_extractors.h` for a comprehensive list of `Extractor`s currently supported. Supporting more `Extractor` and `Argument` should be fairly easy by modeling after current implementation, but can also flexible due to little constraints in the type signature. 
 
-#### Input
+#### The Input
 
 Test input are currently directly feeded into `zetasql_fuzzer:Run` with parameterized `InputType` type. As such, input itself must be a single object of `InputType`, and is compatible with the signature type of supplied `Extractor`s. We have two options for test input as of now: `std::string` input that wraps directly the raw test bytes array from `libfuzzer` engine, or defined proto messages in `protobuf/parameter_grammar.proto` or `protobuf/zetasql_expression_grammar.proto`. See [macro](#the-macro-and-runner) section for how to use wire up these two kinds of fuzzers. 
 
-To accomondate for new kinds of input, `InputType` definition and/or necessary argument `Extractor` should be supplied. If the input is neither of simple wrapper of the raw bytes, or some protobuf message, new macros may be required to correctly wire up correctly the desired input, fuzzing engine interface, and `zetasql_fuzzer::Run` interface together. We recommend readers to model after code in `fuzzer_macro.h` in this situation. For extending new protobuf message input, see [LPM Backend for Structure-aware Fuzzing](#lpm-backend-for-structure-aware-fuzzing)
+To accomondate for new kinds of input, `InputType` definition and/or necessary argument `Extractor` should be supplied. If the input is neither of simple wrapper of the raw bytes, or some protobuf message, new macros may be required to correctly wire up correctly the desired input, fuzzing engine interface, and `zetasql_fuzzer::Run` interface together. We recommend readers to model after code in `fuzzer_macro.h` in this situation. For using or extending new protobuf message input, see [LPM Backend for Structure-aware Fuzzing](#lpm-backend-for-structure-aware-fuzzing)
 
 ## LPM Backend for Structure-aware Fuzzing
 

--- a/zetasql/fuzzing/README.md
+++ b/zetasql/fuzzing/README.md
@@ -1,0 +1,1 @@
+## Documentation of ZetaSQL Fuzzing Library

--- a/zetasql/fuzzing/README.md
+++ b/zetasql/fuzzing/README.md
@@ -1,20 +1,20 @@
-## Documentation of ZetaSQL Fuzzing Library (FAIR)
+# Documentation of ZetaSQL Fuzzing Library (FAIR)
 
-### Code Deprecation and Notes
+## Code Deprecation and Notes
 
 As part of the experimental code, `zetasql_expression_fuzzer.cc` has been replaced by `pipelined_expression_fuzzer.cc` but with FAIR library integration. `zetasql_expression_fuzzer.cc` and its dependencies existed only for convenient bug reproduction. Future developer should model after `pipelined_expression_fuzzer.cc` for correct use of FAIR library.
 
 The current Bazel build dependency isn't exactly at its finest, and combining with `fuzzer_macro.h`, every fuzzer will be compiled with `libprotobuf-mutator` dependency whether it's defined as a `cc_proto_fuzzer` or `cc_fuzzer`. Effort to separate the dependency is welcomed.
 
-### FAIR Library
+## FAIR Library
 
-#### Before you start
+### Before you start
 
 This documentation assumes that readers know how to correctly configure ZetaSQL project and would like to know how to contribute to ZetaSQL fuzzing specifically. Developers who don't have background of Fuzzing Tests or OSS-Fuzz are suggested to take quick tutorials [here](https://github.com/google/fuzzing/blob/master/tutorial/libFuzzerTutorial.md) and [here](https://google.github.io/oss-fuzz/). More references are at the end of this page. For googlers, please refer to evmaus@ for links to presentation of ZetaSQL fuzzing introduction.
 
 The documentation also assumes that reader is comfortable working with [Bazel](https://bazel.build/), and reading `BUILD` file. Since the compilation detail is too remotely related to library itself, we will not go over how to set up build correctly, but to refer readers to the example `BUILD` files.
 
-#### What is FAIR?
+### What is FAIR?
 
 Fuzzers defined in ZetaSQL project currently has a mixed usage of both native libfuzzer interface for primitive fuzzing as well as Libprotobuf-mutator [(LPM)](https://github.com/google/fuzzing/blob/master/docs/structure-aware-fuzzing.md#protocol-buffers-as-intermediate-format) interface for structure aware fuzzing. Additionally, many fuzzers behave in fairly similar ways that they all extract some arguments from the test input and apply them to the tested API. FAIR library deconstructs a general fuzzer into four components and increasing reuse of existing components through composition.
 
@@ -26,7 +26,9 @@ Specifically, FAIR is short for
 - `Input`, an abstraction for any input passed into `zetasql_fuzzer::Run` routine. Current implementation uses template for various input type.
 - `Runner`, an abstraction for fuzzing test routine. Currently implemented as `zetasql_fuzzer::Run`.
 
-#### How to use FAIR?
+### How to use FAIR?
+
+#### The macro
 
 Let's study `simple_evaluator_fuzzer.cc` and `pipelined_expression_fuzzer.cc` as examples. To declare a fuzzer in ZetaSQL, developer should first include `fuzzer_macro.h`, then either choose `ZETASQL_SIMPLE_FUZZER` macro for fuzzing raw test inputs as strings, or `ZETASQL_PROTO_FUZZER` macro for fuzzing structure-aware with LPM interface. 
 
@@ -40,3 +42,67 @@ ZETASQL_SIMPLE_FUZZER(PreparedExpressionTarget, std::make_unique<SQLStringArg, c
 ```
 
 `ZETASQL_SIMPLE_FUZZER` takes the first argument as the concrete subclass of `FuzzTarget`, and all the rest arguments as `Extractor`s, which as we can confirm here is compatible to defined [type signature](#sig). 
+
+In `pipelined_expression_fuzzer.cc`, we have
+
+```c++
+using zetasql_expression_grammar::Expression;
+using zetasql_fuzzer::GetParam;
+using zetasql_fuzzer::GetProtoExpr;
+using zetasql_fuzzer::PreparedExpressionTarget;
+
+using As = zetasql_fuzzer::ParameterValueAs;
+
+ZETASQL_PROTO_FUZZER(Expression, PreparedExpressionTarget, GetProtoExpr,
+                     GetParam<As::COLUMNS>, GetParam<As::PARAMETERS>);
+```
+
+The code looks intimidating, but really what it does is that `ZETASQL_PROTO_FUZZER` takes the first argument as the `InputType` (i.e., we declare the current fuzzer input is of type `Expression`), the second argument as the concrete subclass of `FuzzTarget`, and all the rest as `Extractor`s, compatible to defined [type signature](#sig).
+
+#### The Fuzz Target
+
+So what is the `PreparedExpressionTarget`? Let's take a look at `component/fuzz_targets/fuzz_target.h` first.
+
+```c++
+class FuzzTarget {
+ public:
+  virtual ~FuzzTarget() = default;
+  virtual void Visit(SQLStringArg& arg) { AbortVisit("SQLStringArg&"); }
+  virtual void Visit(ParameterValueMapArg& arg) { AbortVisit("ParameterValueMapArg&"); }
+  virtual void Visit(ParameterValueListArg& arg) { AbortVisit("ParameterValueListArg&"); 
+  virtual void Execute() = 0;
+```
+
+As defined earlier, FuzzTarget is an abstraction for any ZetaSQL API to be fuzzed. `PreparedExpressionTarget` is really just a concrete subclass of `FuzzTarget` that knows how to execute `PreparedExpression::Execute` function. Now take a look at the implementation of `PreparedExpressionTarget`,
+
+```c++
+// prepared_expression_target.h
+class PreparedExpressionTarget : public FuzzTarget {
+ public:
+  void Visit(SQLStringArg& sql) override;
+  void Visit(ParameterValueMapArg& arg) override;
+  void Execute() override;
+
+ private:
+  std::unique_ptr<std::string> sql_expression_;
+  std::unique_ptr<zetasql::ParameterValueMap> columns_;
+  std::unique_ptr<zetasql::ParameterValueMap> parameters_;
+};
+
+// prepared_expression_target.cc
+void PreparedExpressionTarget::Visit(SQLStringArg& arg) {
+  sql_expression_ = arg.Release().ValueOrDie();
+}
+
+...
+
+void PreparedExpressionTarget::Execute() {
+  if (!sql_expression_) {
+    LOG(FATAL) << "SQL expression not found";
+  }
+  zetasql::PreparedExpression expression(*sql_expression_);
+  expression.Execute(GetOrDefault(columns_), GetOrDefault(parameters_));
+}
+```
+
+We see that the PreparedExpressionTarget knows exactly how to get the argument value from available `zetasql_fuzzer::Argument`, and how to execute the fuzzed API. Additionally, notice that `PreparedExpressionTarget` doesn't override `#Visit(ParameterValueListArg& arg)` function. This means that it doesn't know how to get the argument, because the underlying calls never need it! This is convienient because `FuzzTarget.h` provides a default implementation, so we don't need to handle arguments irrelavant of the fuzzed API. If an unhandled argument is accidentally introduced, the program will crash and complain so we know that we set up the fuzzer incorrectly. 

--- a/zetasql/fuzzing/README.md
+++ b/zetasql/fuzzing/README.md
@@ -1,1 +1,42 @@
-## Documentation of ZetaSQL Fuzzing Library
+## Documentation of ZetaSQL Fuzzing Library (FAIR)
+
+### Code Deprecation and Notes
+
+As part of the experimental code, `zetasql_expression_fuzzer.cc` has been replaced by `pipelined_expression_fuzzer.cc` but with FAIR library integration. `zetasql_expression_fuzzer.cc` and its dependencies existed only for convenient bug reproduction. Future developer should model after `pipelined_expression_fuzzer.cc` for correct use of FAIR library.
+
+The current Bazel build dependency isn't exactly at its finest, and combining with `fuzzer_macro.h`, every fuzzer will be compiled with `libprotobuf-mutator` dependency whether it's defined as a `cc_proto_fuzzer` or `cc_fuzzer`. Effort to separate the dependency is welcomed.
+
+### FAIR Library
+
+#### Before you start
+
+This documentation assumes that readers know how to correctly configure ZetaSQL project and would like to know how to contribute to ZetaSQL fuzzing specifically. Developers who don't have background of Fuzzing Tests or OSS-Fuzz are suggested to take quick tutorials [here](https://github.com/google/fuzzing/blob/master/tutorial/libFuzzerTutorial.md) and [here](https://google.github.io/oss-fuzz/). More references are at the end of this page. For googlers, please refer to evmaus@ for links to presentation of ZetaSQL fuzzing introduction.
+
+The documentation also assumes that reader is comfortable working with [Bazel](https://bazel.build/), and reading `BUILD` file. Since the compilation detail is too remotely related to library itself, we will not go over how to set up build correctly, but to refer readers to the example `BUILD` files.
+
+#### What is FAIR?
+
+Fuzzers defined in ZetaSQL project currently has a mixed usage of both native libfuzzer interface for primitive fuzzing as well as Libprotobuf-mutator [(LPM)](https://github.com/google/fuzzing/blob/master/docs/structure-aware-fuzzing.md#protocol-buffers-as-intermediate-format) interface for structure aware fuzzing. Additionally, many fuzzers behave in fairly similar ways that they all extract some arguments from the test input and apply them to the tested API. FAIR library deconstructs a general fuzzer into four components and increasing reuse of existing components through composition.
+
+Specifically, FAIR is short for 
+
+- `FuzzTarget`, an abstraction for any ZetaSQL API to be fuzzed. It encapsulates the logic of setting up calls to ZetaSQL API given correct arguments. During fuzzing, arguments of the API calls can be extracted by visiting available `zetasql_fuzzer::Argument`. It is a Visitor to `zetasql_fuzzer::Argument`.
+- `Argument`, an abstraction for any value that is extracted from the fuzzing input of `InputType` in `zetasql_fuzzer::Run` routine, and is to be applied to some `zetasql_fuzzer::FuzzTarget` in a fuzzing test. It is a Visitable to `zetasql::FuzzTarget`.
+  - `Extractor`, a function that can extract some `Argument` from an input of `InputType`. The <a id='sig'>signature</a> should be compatible to `std::function<std::unique_ptr<zetasql_fuzzer::Argument>(const InputType&)>`
+- `Input`, an abstraction for any input passed into `zetasql_fuzzer::Run` routine. Current implementation uses template for various input type.
+- `Runner`, an abstraction for fuzzing test routine. Currently implemented as `zetasql_fuzzer::Run`.
+
+#### How to use FAIR?
+
+Let's study `simple_evaluator_fuzzer.cc` and `pipelined_expression_fuzzer.cc` as examples. To declare a fuzzer in ZetaSQL, developer should first include `fuzzer_macro.h`, then either choose `ZETASQL_SIMPLE_FUZZER` macro for fuzzing raw test inputs as strings, or `ZETASQL_PROTO_FUZZER` macro for fuzzing structure-aware with LPM interface. 
+
+In `simple_evaluator_fuzzer.cc`, we have 
+
+```c++
+using zetasql_fuzzer::PreparedExpressionTarget;
+using zetasql_fuzzer::SQLStringArg;
+
+ZETASQL_SIMPLE_FUZZER(PreparedExpressionTarget, std::make_unique<SQLStringArg, const std::string&>);
+```
+
+`ZETASQL_SIMPLE_FUZZER` takes the first argument as the concrete subclass of `FuzzTarget`, and all the rest arguments as `Extractor`s, which as we can confirm here is compatible to defined [type signature](#sig). 

--- a/zetasql/fuzzing/README.md
+++ b/zetasql/fuzzing/README.md
@@ -105,7 +105,7 @@ void PreparedExpressionTarget::Execute() {
 }
 ```
 
-We see that the PreparedExpressionTarget knows exactly how to get the argument value from available `zetasql_fuzzer::Argument`, and how to execute the fuzzed API. Additionally, notice that `PreparedExpressionTarget` doesn't override `#Visit(ParameterValueListArg& arg)` function. This means that it doesn't know how to get the argument, because the underlying calls never need it! This is convienient because `FuzzTarget.h` provides a default implementation, so we don't need to handle arguments irrelavant of the fuzzed API. If an unhandled argument is accidentally introduced, the program will crash and complain so we know that we set up the fuzzer incorrectly. 
+We see that the PreparedExpressionTarget knows exactly how to get the argument value from available `zetasql_fuzzer::Argument`, and how to execute the fuzzed API. Additionally, notice that `PreparedExpressionTarget` doesn't override `#Visit(ParameterValueListArg& arg)` function. This means that it doesn't know how to get the argument, because the underlying calls never need it! This is convenient because `FuzzTarget.h` provides a default implementation, so we don't need to handle arguments irrelavant of the fuzzed API. If an unhandled argument is accidentally introduced, the program will crash and complain so we know that we set up the fuzzer incorrectly. 
 
 #### The Argument & Extractors
 

--- a/zetasql/fuzzing/README.md
+++ b/zetasql/fuzzing/README.md
@@ -2,7 +2,7 @@
 
 ## Code Deprecation and Notes
 
-As part of the experimental code, `zetasql_expression_fuzzer.cc` has been replaced by `pipelined_expression_fuzzer.cc` but with FAIR library integration. `zetasql_expression_fuzzer.cc` and its dependencies exists only for existing bug reproduction. Future developer should model after `pipelined_expression_fuzzer.cc` for correct use of FAIR library.
+As part of the experimental code, `zetasql_expression_fuzzer.cc` has been replaced by `pipelined_expression_fuzzer.cc` but with FAIR library integration. `zetasql_expression_fuzzer.cc` and its dependencies exists only for existing bug reproduction. Future developers should model after `pipelined_expression_fuzzer.cc` for correct use of FAIR library.
 
 The current Bazel build dependency isn't exactly at its finest, and combining with `fuzzer_macro.h`, every fuzzer will be compiled with `libprotobuf-mutator` dependency whether it's defined as a `cc_proto_fuzzer` or `cc_fuzzer`. Effort to separate the dependency is welcomed.
 
@@ -10,27 +10,27 @@ The current Bazel build dependency isn't exactly at its finest, and combining wi
 
 ### Before you start
 
-This documentation assumes that readers know how to correctly configure ZetaSQL project and would like to know how to contribute to ZetaSQL fuzzing specifically. Developers who don't have background of Fuzzing Tests or OSS-Fuzz are suggested to take quick tutorials [here](https://github.com/google/fuzzing/blob/master/tutorial/libFuzzerTutorial.md) and [here](https://google.github.io/oss-fuzz/). More references are at the end of this page. For googlers, please refer to evmaus@ for links to presentation of ZetaSQL fuzzing introduction.
+This documentation assumes that readers know how to correctly configure ZetaSQL project and would like to contribute to ZetaSQL fuzzing specifically. Developers who don't have background in F=fuzzing tests or OSS-Fuzz are suggested to take quick tutorials [here](https://github.com/google/fuzzing/blob/master/tutorial/libFuzzerTutorial.md) and [here](https://google.github.io/oss-fuzz/). More references are at the end of this page. For googlers, please refer to evmaus@ for links to the presentation of ZetaSQL fuzzing introduction.
 
-The documentation also assumes that readers are comfortable working with [Bazel](https://bazel.build/), and reading `BUILD` file. Since the compilation detail is too remotely related to library itself, we will not go over how to set up build correctly, but to refer readers to the example `BUILD` files.
+The documentation also assumes that readers are comfortable working with [Bazel](https://bazel.build/), and reading `BUILD` file. Since the compilation detail is too remotely related to library itself, setting up build will not be covered in this documentation. Readers are suggested to read example `BUILD` files instead.
 
 ### What is FAIR?
 
-Fuzzers defined in ZetaSQL project currently has a mixed usage of both native libfuzzer interface for primitive fuzzing as well as Libprotobuf-mutator [(LPM)](https://github.com/google/fuzzing/blob/master/docs/structure-aware-fuzzing.md#protocol-buffers-as-intermediate-format) interface for structure aware fuzzing. Additionally, many fuzzers behave in fairly similar ways that they all extract some arguments from the test input and apply them to the tested API. FAIR library deconstructs a general fuzzer into four components and increasing reuse of existing components through composition.
+Fuzzers defined in ZetaSQL project currently have a mixed usage of both native `libfuzzer` interface for primitive fuzzing, as well as Libprotobuf-mutator [(LPM)](https://github.com/google/fuzzing/blob/master/docs/structure-aware-fuzzing.md#protocol-buffers-as-intermediate-format) interface for structure aware fuzzing. Additionally, many fuzzers behave in fairly similar ways that they all extract some arguments from the test input and apply them to the tested API. FAIR library deconstructs general fuzzers into four components and helps increase code reuse through composition.
 
 Specifically, FAIR is short for 
 
-- `FuzzTarget`, an abstraction for any ZetaSQL API to be fuzzed. It encapsulates the logic of setting up calls to ZetaSQL API given correct arguments. During fuzzing, arguments of the API calls can be extracted by visiting available `zetasql_fuzzer::Argument`. It is a Visitor to `zetasql_fuzzer::Argument`.
-- <a id='arg'>`Argument`</a>, an abstraction for any value that is extracted from the fuzzing input of `InputType` in `zetasql_fuzzer::Run` routine, and is to be applied to some `zetasql_fuzzer::FuzzTarget` in a fuzzing test. It is a Visitable to `zetasql::FuzzTarget`.
-  - `Extractor`, a function that can extract some `Argument` from an input of `InputType`. The <a id='sig'>signature</a> should be compatible to `std::function<std::unique_ptr<zetasql_fuzzer::Argument>(const InputType&)>`
-- `Input`, an abstraction for any input passed into `zetasql_fuzzer::Run` routine. Current implementation uses template for various input type.
-- `Runner`, an abstraction for **engine-agnostic** fuzzing test routine. Currently implemented as `zetasql_fuzzer::Run`. See [The macro and Runner](#the-macro-and-runner) for correct use. 
+- `zetasql_fuzzer::FuzzTarget`, an abstraction for any ZetaSQL APIs to be fuzzed. It encapsulates the logic of setting up calls to ZetaSQL APIs given correct arguments. During fuzzing, `zetasql_fuzzer::FuzzTarget` gets arguments for the API calls by visiting available `zetasql_fuzzer::Argument`s. `zetasql_fuzzer::FuzzTarget` is a Visitor to `zetasql_fuzzer::Argument`.
+- <a id='arg'>`zetasql_fuzzer::Argument`</a>, an abstraction for any value that is extracted from the fuzzing input of `InputType` in `zetasql_fuzzer::Run` routine, and is to be applied to some `zetasql_fuzzer::FuzzTarget` in a fuzzing test. It is a Visitable to `zetasql::FuzzTarget`.
+  - `Extractor`, a function that can extract some `zetasql_fuzzer::Argument` from an input of `InputType`. The signature should be compatible to <a id='sig'>`std::function<std::unique_ptr<zetasql_fuzzer::Argument>(const InputType&)>`</a>
+- `Input`, an abstraction for any input passed into `zetasql_fuzzer::Run` routine. Current implementation uses `template <typename InputType>` for various inputs.
+- `Runner`, an abstraction for **engine-agnostic** fuzzing test routine, currently implemented as `zetasql_fuzzer::Run`. See [The Macro and Runner](#the-macro-and-runner) for correct use. 
 
 ### How to use FAIR?
 
-#### The macro and Runner
+#### The Macro and Runner
 
-Let's study `simple_evaluator_fuzzer.cc` and `pipelined_expression_fuzzer.cc` as examples. To declare a fuzzer in ZetaSQL, developer should first include `fuzzer_macro.h`, then either choose `ZETASQL_SIMPLE_FUZZER` macro for fuzzing raw test inputs as strings, or `ZETASQL_PROTO_FUZZER` macro for fuzzing structure-aware with LPM interface (see [LPM Backend for Structure-aware Fuzzing](#lpm-backend-for-structure-aware-fuzzing)). 
+Let's study `simple_evaluator_fuzzer.cc` and `pipelined_expression_fuzzer.cc` as examples. To declare a fuzzer in ZetaSQL, developers should first include `fuzzer_macro.h`, then choose either `ZETASQL_SIMPLE_FUZZER` macro for fuzzing raw test inputs as strings, or `ZETASQL_PROTO_FUZZER` macro for fuzzing structure-aware with LPM interface (see also [LPM Backend for Structure-aware Fuzzing](#lpm-backend-for-structure-aware-fuzzing)). 
 
 In `simple_evaluator_fuzzer.cc`, we have 
 
@@ -41,7 +41,7 @@ using zetasql_fuzzer::SQLStringArg;
 ZETASQL_SIMPLE_FUZZER(PreparedExpressionTarget, std::make_unique<SQLStringArg, const std::string&>);
 ```
 
-`ZETASQL_SIMPLE_FUZZER` takes the first argument as the concrete subclass of `FuzzTarget`, and all the rest arguments as `Extractor`s, which as we can confirm here is compatible to defined [type signature](#sig). 
+`ZETASQL_SIMPLE_FUZZER` takes the first argument as the concrete subclass of `zetasql_fuzzer::FuzzTarget`, and all the rest arguments as `Extractor`s, which as we can confirm here is compatible to defined [type signature](#sig). 
 
 In `pipelined_expression_fuzzer.cc`, we have
 
@@ -57,13 +57,13 @@ ZETASQL_PROTO_FUZZER(Expression, PreparedExpressionTarget, GetProtoExpr,
                      GetParam<As::COLUMNS>, GetParam<As::PARAMETERS>);
 ```
 
-The code looks intimidating, but really what it does is that `ZETASQL_PROTO_FUZZER` takes the first argument as the `InputType` (i.e., we declare the current fuzzer input is of type `Expression`), the second argument as the concrete subclass of `FuzzTarget`, and all the rest as `Extractor`s, compatible to defined [type signature](#sig).
+The code looks intimidating, but really what it does is that `ZETASQL_PROTO_FUZZER` takes the first argument as the `InputType` (here we declare the current fuzzer input is of type `Expression`), the second argument as the concrete subclass of `zetasql_fuzzer::FuzzTarget`, and all the rest as `Extractor`s, compatible to defined [type signature](#sig).
 
-Under the hood, these macros instantiate the fuzz target interface for `libfuzzer` and LPM respectively, and then invoke `zetasql_fuzzer::Run` in the instantiation, with test input of either `std::string` in `ZETASQL_SIMPLE_FUZZER` or the supplied type (e.g., `Expression`) in `ZETASQL_PROTO_FUZZER`. See also [input](#the-input) section for more detail about using different types of inputs.
+Under the hood, these macros instantiate the engine interface for `libfuzzer` and LPM respectively, and then invoke `zetasql_fuzzer::Run` with test input of `std::string` and the supplied type (e.g., `Expression`), respectively. See also [The Input](#the-input) section for more detail about using different types of inputs.
 
-The point of `zetasql_fuzzer::Run` being engine agnostic is that we want to separate the engine setup from fuzzing test logic, so that the latter can be reused in different engine in the future. As a result, however, `zetasql_fuzzer::Run` **must** be used inside an interface provided by a fuzzing engine. Using a macro is therefore recommended to avoid the hassle of learning engine interface. 
+The point of `zetasql_fuzzer::Run` being engine agnostic is the separation of engine setup from fuzzing test logic, so that the latter can be reused in different engines. As a result, however, `zetasql_fuzzer::Run` **must** be used inside an interface provided by a fuzzing engine. Using a macro is therefore recommended to avoid the hassle of learning engine interface. 
 
-Addtionally, there can be **exactly one** engine interface (therefore, one macro) be instantiated per fuzzing test. This is because every fuzzing test will be compiled into a standalone binary. Declaring two or more fuzzing tests in a fuzzer source file causes compilation error. 
+Addtionally, there can be **exactly one** engine interface (therefore, one macro) be instantiated per fuzzing test. This is because every fuzzing test will be compiled into a standalone binary. Declaring two or more fuzz targets in a fuzzer source file causes compilation error. 
 
 #### The Fuzz Target
 
@@ -79,7 +79,7 @@ class FuzzTarget {
   virtual void Execute() = 0;
 ```
 
-As defined earlier, FuzzTarget is an abstraction for any ZetaSQL API to be fuzzed. In a declared fuzzer with FAIR, a `FuzzTarget` object will be instantiated and executed after all available `Argument`s have been visited. `PreparedExpressionTarget` is really just a concrete subclass of `FuzzTarget` that knows how to execute `PreparedExpression::Execute` function. Now take a look at the implementation of `PreparedExpressionTarget`,
+As explained earlier, `zetasql_fuzzer::FuzzTarget` is an abstraction for any ZetaSQL APIs to be fuzzed. In a declared fuzzer with FAIR, a `FuzzTarget` object will be instantiated and executed after all available `Argument`s have been visited. `PreparedExpressionTarget` is really just a concrete subclass of `FuzzTarget` that knows how to execute `PreparedExpression::Execute` function. Now take a look at the implementation of `PreparedExpressionTarget`,
 
 ```c++
 // component/fuzz_targetsprepared_expression_target.h
@@ -111,11 +111,11 @@ void PreparedExpressionTarget::Execute() {
 }
 ```
 
-We see that the `PreparedExpressionTarget` knows exactly how to get the argument value from available `zetasql_fuzzer::Argument`, and how to execute the fuzzed API. Additionally, notice that `PreparedExpressionTarget` doesn't override `#Visit(ParameterValueListArg& arg)` function. This means that it doesn't know how to get the argument, because the underlying calls never need it! This is convenient because `FuzzTarget.h` provides a default implementation, so we don't need to handle arguments irrelavant of the fuzzed API. If an unhandled argument is accidentally introduced, the program will crash and complain so we know that we set up the fuzzer incorrectly. 
+We see how `PreparedExpressionTarget` gets the argument value from available `zetasql_fuzzer::SQLStringArg`, and executes the fuzzed API. Additionally, notice that `PreparedExpressionTarget` doesn't override `#Visit(ParameterValueListArg& arg)` function. This means that it doesn't know how to get the argument, because the underlying calls never need it! This is convenient because `FuzzTarget` provides a default implementation, so we don't need to handle arguments irrelavant of the fuzzed API. If an unhandled argument is accidentally introduced, the program will crash and complain so we know that we set up the fuzzer incorrectly. 
 
 #### The Argument & Extractors
 
-According to the [defintion](#arg), `Argument`s are essentially value containers used by `FuzzTarget`. However, `Argument` is not aware of test input directly, but relies on `Extractor`s to do the translation work. As such, the modularization between `FuzzTarget` and `Extractor`s is guaranteed, so that `FuzzTarget` can be mix-and-matched with `Extractor`s for different inputs as long the resulting argument is compatible.  
+According to the [defintion](#arg), `Argument`s are essentially value containers used by `FuzzTarget`. However, `Argument` is not aware of test input directly, but relies on `Extractor`s to do the translation work. As such, the modularization between `FuzzTarget` and `Extractor`s is guaranteed, so that `FuzzTarget`s can be mix-and-matched with `Extractor`s for different inputs as long the resulting arguments are compatible.  
 
 ```c++
 class Argument {
@@ -148,25 +148,25 @@ class SQLStringArg : public TypedArg<std::string> {
 };
 ```
 
-`Argument` is implemented as a type-erased container, and combined with Visitor pattern, `Argument` yields great flexibility for both `FuzzTarget` and `Extractor`. `Extractor` can be as simple as `std::make_unique<SQLStringArg, const std::string&>` in the case of `simple_evaluator_fuzzer.cc`, or as complicated as `GetParam<As::PARAMETERS>` in `piplined_expression_fuzzer.cc`. For LPM based structure aware fuzzer, see [LPM Backend for Structure-aware Fuzzing](#lpm-backend-for-structure-aware-fuzzing). Supporting more `Extractor` and `Argument` should be fairly easy by modeling after current implementation, but can also flexible due to little constraints in the type signature. 
+`Argument` is implemented as a type-erased container, and combined with Visitor pattern, `Argument` yields great flexibility for both `FuzzTarget` and `Extractor`. `Extractor` can be as simple as `std::make_unique<SQLStringArg, const std::string&>` as in `simple_evaluator_fuzzer.cc`, or as complicated as `GetParam<As::PARAMETERS>` in `piplined_expression_fuzzer.cc` (see [LPM Backend for Structure-aware Fuzzing](#lpm-backend-for-structure-aware-fuzzing)). Supporting more `Extractor` and `Argument` should be fairly easy by modeling after current implementation.
 
 #### The Input
 
-Test input are currently directly feeded into `zetasql_fuzzer:Run` with parameterized `InputType` type. As such, input itself must be a single object of `InputType`, and is compatible with the signature type of supplied `Extractor`s. We have two options for test input as of now: `std::string` input that wraps directly the raw test bytes array from `libfuzzer` engine, or defined proto messages. See [macro](#the-macro-and-runner) section for how to use wire up these two kinds of fuzzers. 
+Test inputs parameterized `InputType` type are directly feeded into `zetasql_fuzzer:Run`, and must be compatible with supplied `Extractor`s. Since the `InputType` is invariant for a specific fuzzer, all `Extactor`s for a fuzzer should share the same function signature. We currently have two options for test input as of now: `std::string` input that wraps directly the raw test bytes array from `libfuzzer` engine, or defined proto messages. See [macro](#the-macro-and-runner) section for how to use wire up these two kinds of fuzzers. 
 
-To accomondate for new kinds of input, `InputType` definition and/or necessary argument `Extractor` should be supplied. If the input is neither of simple wrapper of the raw bytes, or some protobuf message, new macros may be required to correctly wire up correctly the desired input, fuzzing engine interface, and `zetasql_fuzzer::Run` interface together. We recommend readers to model after code in `fuzzer_macro.h` in this situation. For using or extending new protobuf message input, see [LPM Backend for Structure-aware Fuzzing](#lpm-backend-for-structure-aware-fuzzing)
+To accomondate for new kinds of input, `InputType` definition and/or necessary `Extractor` should be supplied. If the input is neither simple wrapper of the raw bytes, or some protobuf message, new macros may be required to correctly wire up the desired input, fuzzing engine interface, and `zetasql_fuzzer::Run` interface together. We recommend readers to model after code in `fuzzer_macro.h` in this situation. For using or extending new protobuf message input, see [LPM Backend for Structure-aware Fuzzing](#lpm-backend-for-structure-aware-fuzzing)
 
 ## LPM Backend for Structure-aware Fuzzing
 
-ZetaSQL Fuzzing project uses Libprotobuf-mutator [(LPM)](https://github.com/google/fuzzing/blob/master/docs/structure-aware-fuzzing.md#protocol-buffers-as-intermediate-format) as the structure aware fuzzing infrastructure. As a short introduction, Google protobuf messages provides a nice way to represent data encoding schema and LPM takes advantage of it by parsing fuzzing inputs into some protobuf message, and mutating only the content of the protobuf message. As the user of LPM, we only need to decode the protobuf correctly (i.e., extract useful data following the defined schema) to perform structure aware fuzzing. This approach aligns fairly well with representing and mutating SQL abstract syntax tree (AST). 
+ZetaSQL Fuzzing project uses Libprotobuf-mutator [(LPM)](https://github.com/google/fuzzing/blob/master/docs/structure-aware-fuzzing.md#protocol-buffers-as-intermediate-format) as the structure aware fuzzing infrastructure. As a short introduction, Google protobuf messages provides a nice way to represent data schema and LPM takes advantage of it by parsing fuzzing inputs into some protobuf message, and mutating only the content of the protobuf message. As the user of LPM, we only need to decode the protobuf correctly (i.e., extract useful data following the defined schema) to perform structure aware fuzzing. This approach aligns fairly well with representing and mutating SQL abstract syntax tree (AST). 
 
 ### Input
 
-LPM supplies defined protobuf message as argument to the declared fuzz targets. As explained earlier, the message type (i.e., class) should be specified in `ZETASQL_PROTO_FUZZER` as the first argument. Doing so tells the engine what message type to use for this fuzz test.  Currently supported AST structures are binary arithmetic expressions with arbitrary literals or variable (as column or parameter), defined in `protobuf/zetasql_expression_grammar.proto` and `protobuf/parameter_grammar.proto`. Future extension on SQL language feature can model after current solution.
+LPM supplies defined protobuf messages as test inputs to the declared fuzz targets. As explained earlier, the message type (i.e., class) should be specified in `ZETASQL_PROTO_FUZZER` as the first argument. Doing so tells the engine what message type to use for this fuzz test. Currently supported AST messages are binary arithmetic expressions with arbitrary literals or variables (as columns or parameters), defined in `protobuf/zetasql_expression_grammar.proto` and `protobuf/parameter_grammar.proto`. Future extension on SQL language feature can model after current solution.
 
 ### Argument Extractors
 
-`protobuf/argument_extractors.h` provides a comprehensive list of `zetasql_fuzzer::Extractor`s currently supported. Internally they use implementations of `zetasql_fuzzer::internal::ProtoExprExtractor` or `zetasql_fuzzer::internal::LiteralExtractor` in `protobuf/internal/syntax_tree_visitor.h` that defines helper classes to correctly extract encoded data from protobuf message, such as the SQL statement string or parameter values. `protobuf/internal/` directory curates all implementations of `zetasql_fuzzer::internal::Extractor` interfaces.
+`protobuf/argument_extractors.h` provides a comprehensive list of `zetasql_fuzzer::Extractor`s currently supported for extracting from AST messages. Internally they use implementations of `zetasql_fuzzer::internal::ProtoExprExtractor` or `zetasql_fuzzer::internal::LiteralExtractor` in `protobuf/internal/syntax_tree_visitor.h` that defines helper classes to correctly extract encoded data from protobuf message, such as the SQL statement string or parameter values. `protobuf/internal/` directory curates all implementations of `zetasql_fuzzer::internal::Extractor` interfaces.
 
 ```c++
 template <typename Result>
@@ -197,4 +197,13 @@ class ProtoExprExtractor : public Extractor<Result> {
 };
 ```
 
-Notice that `zetasql_fuzzer::internal::Extractor` is different from `zetasql_fuzzer::Extractor`, the latter uses the former as the implementation dependency to actually extract the `zetasql_fuzzer::Argument` from any protobuf message.
+Notice that `zetasql_fuzzer::internal::Extractor` is different from `zetasql_fuzzer::Extractor`, implementations of the latter can use that of the former as the compositional dependency to actually extract the `zetasql_fuzzer::Argument` from any protobuf message.
+
+## References
+
+- Google Fuzzing Forum: https://github.com/google/fuzzing
+- OSS-Fuzz: https://google.github.io/oss-fuzz/
+- Fuzzing Tutorial: https://github.com/google/fuzzing/blob/master/tutorial/libFuzzerTutorial.md
+- Bazel: https://bazel.build/
+- Libprotobuf-mutator: https://github.com/google/libprotobuf-mutator
+- Protocol Buffers: https://developers.google.com/protocol-buffers

--- a/zetasql/fuzzing/README.md
+++ b/zetasql/fuzzing/README.md
@@ -2,7 +2,7 @@
 
 ## Code Deprecation and Notes
 
-As part of the experimental code, `zetasql_expression_fuzzer.cc` has been replaced by `pipelined_expression_fuzzer.cc` but with FAIR library integration. `zetasql_expression_fuzzer.cc` and its dependencies existed only for convenient bug reproduction. Future developer should model after `pipelined_expression_fuzzer.cc` for correct use of FAIR library.
+As part of the experimental code, `zetasql_expression_fuzzer.cc` has been replaced by `pipelined_expression_fuzzer.cc` but with FAIR library integration. `zetasql_expression_fuzzer.cc` and its dependencies existed only for existing bug reproduction. Future developer should model after `pipelined_expression_fuzzer.cc` for correct use of FAIR library.
 
 The current Bazel build dependency isn't exactly at its finest, and combining with `fuzzer_macro.h`, every fuzzer will be compiled with `libprotobuf-mutator` dependency whether it's defined as a `cc_proto_fuzzer` or `cc_fuzzer`. Effort to separate the dependency is welcomed.
 

--- a/zetasql/fuzzing/README.md
+++ b/zetasql/fuzzing/README.md
@@ -132,6 +132,14 @@ class TypedArg : public Argument {
  private:
   std::unique_ptr<ArgType> argument_;
 };
+
+class SQLStringArg : public TypedArg<std::string> {
+ public:
+  using TypedArg::TypedArg;
+  void Accept(zetasql_fuzzer::FuzzTarget& function) override {
+    function.Visit(*this);
+  }
+};
 ```
 
 `Argument` is implemented as a type-erased container, and combined with Visitor pattern, `Argument` yields great flexibility for both `FuzzTarget` and `Extractor`. `Extractor` can be as simple as `std::make_unique<SQLStringArg, const std::string&>` in the case of `simple_evaluator_fuzzer.cc`, or as complicated as `GetParam<As::PARAMETERS>` in `piplined_expression_fuzzer`. For LPM based structure aware fuzzer, we refer readers to `protobuf/argument_extractors.h` for a comprehensive list of `Extractor`s currently supported. Supporting more `Extractor` and `Argument` should be fairly easy by modeling after current implementation, but can also flexible due to little constraints in the type signature. 

--- a/zetasql/fuzzing/component/arguments/argument.h
+++ b/zetasql/fuzzing/component/arguments/argument.h
@@ -23,8 +23,15 @@
 #include "zetasql/base/statusor.h"
 #include "zetasql/fuzzing/component/fuzz_targets/fuzz_target.h"
 
+// Argument defines an abstraction for any value that is extracted from 
+// the fuzzing input of InputType in zetasql_fuzzer::Run function,
+// and is to be applied to some zetasql_fuzzer::FuzzTarget in a fuzzing test.
+//
+// Argument is a Visitable to zetasql_fuzzer::FuzzTarget
+
 namespace zetasql_fuzzer {
 
+// Defines a type-erased abstract base class
 class Argument {
  public:
   virtual ~Argument() = default;
@@ -33,6 +40,7 @@ class Argument {
   virtual void Accept(zetasql_fuzzer::FuzzTarget& function) = 0;
 };
 
+// Defines a move-only template argument container holding value of ArgType
 template <typename ArgType>
 class TypedArg : public Argument {
  public:
@@ -61,6 +69,8 @@ class TypedArg : public Argument {
   std::unique_ptr<ArgType> argument_;
 };
 
+// Defines an argument container for extracted SQL statement string 
+// from input of InputType in zetasql_fuzzer::Run
 class SQLStringArg : public TypedArg<std::string> {
  public:
   using TypedArg::TypedArg;

--- a/zetasql/fuzzing/component/arguments/parameter_value_argument.h
+++ b/zetasql/fuzzing/component/arguments/parameter_value_argument.h
@@ -20,6 +20,11 @@
 #include "zetasql/fuzzing/component/arguments/argument.h"
 #include "zetasql/public/evaluator_base.h"
 
+// Defines argument containers for parameter values extracted from input in zetasql_fuzzer::Run,
+// and used by zetasql::Evaluator;
+// See zetasql/public/evaluator_base.h for usage of ParameterValueMap and ParameterValueList,
+// See zetasql/fuzzing/component/arguments/argument.h for definition of zetasql_fuzzer::Argument
+
 namespace zetasql_fuzzer {
 
 enum ParameterValueAs { COLUMNS, PARAMETERS };

--- a/zetasql/fuzzing/component/fuzz_targets/fuzz_target.h
+++ b/zetasql/fuzzing/component/fuzz_targets/fuzz_target.h
@@ -23,6 +23,13 @@
 #include "zetasql/base/logging.h"
 #include "zetasql/public/evaluator_base.h"
 
+// FuzzTarget defines an abstraction for any ZetaSQL API to be fuzzed; it 
+// encapsulates the logic of setting up call to ZetaSQL API given correct arguments
+// During fuzzing, arguments of the API call can be extracted by visiting 
+// available zetasql_fuzzer::Argument.
+//
+// FuzzTarget is a Visitor to zetasql_fuzzer::Argument
+
 namespace zetasql_fuzzer {
 
 class SQLStringArg;
@@ -41,14 +48,14 @@ class FuzzTarget {
   template <typename T>
   static const T& GetOrDefault(
       const std::unique_ptr<T>& ptr) {
-    static const T DEFAULT_VALUE_MAP;
-    return ptr ? *ptr : DEFAULT_VALUE_MAP;
+    static const T DEFAULT_VALUE;
+    return ptr ? *ptr : DEFAULT_VALUE;
   }
 
  private:
   void AbortVisit(const std::string& type) {
     LOG(FATAL) << "#Visit(" << type
-              << ") not implemented. Instantiate this method in the subclass";
+              << ") not implemented. Instantiate this method in the FuzzTarget subclass";
   }
 };
 

--- a/zetasql/fuzzing/component/fuzz_targets/prepared_expression_positional_target.h
+++ b/zetasql/fuzzing/component/fuzz_targets/prepared_expression_positional_target.h
@@ -21,6 +21,7 @@
 
 namespace zetasql_fuzzer {
 
+// Defines encapsulation of zetasql::PreparedExpression::ExecuteWithPositionalParams API
 class PreparedExpressionPositionalTarget : public FuzzTarget {
  public:
   void Visit(SQLStringArg& sql) override;

--- a/zetasql/fuzzing/component/fuzz_targets/prepared_expression_target.h
+++ b/zetasql/fuzzing/component/fuzz_targets/prepared_expression_target.h
@@ -21,6 +21,7 @@
 
 namespace zetasql_fuzzer {
 
+// Defines encapsulation of zetasql::PreparedExpression::ExecuteWithPositionalParams API
 class PreparedExpressionTarget : public FuzzTarget {
  public:
   void Visit(SQLStringArg& sql) override;

--- a/zetasql/fuzzing/component/runner.h
+++ b/zetasql/fuzzing/component/runner.h
@@ -30,6 +30,9 @@
 namespace zetasql_fuzzer {
 
 #ifdef __OSS_FUZZ__
+// Configure timezone data dependency for ZetaSQL runtime in OSS-Fuzz 
+// docker environment, which doesn't have tzdata dependency installed.
+// See also https://github.com/google/oss-fuzz/pull/4010
 bool DoOssFuzzInit() {
   namespace fs = std::filesystem;
   static const int OVERWRITE = 1;
@@ -48,6 +51,7 @@ bool DoOssFuzzInit() {
 }
 #endif  // __OSS_FUZZ__
 
+// Defines the driver function for ZetaSQL fuzzing tests
 template <typename InputType, typename TargetType, typename... Functions>
 void Run(const InputType& input, Functions... functions) {
 #ifdef __OSS_FUZZ__

--- a/zetasql/fuzzing/fuzzer_macro.h
+++ b/zetasql/fuzzing/fuzzer_macro.h
@@ -24,11 +24,15 @@
 #include "libprotobuf_mutator/src/libfuzzer/libfuzzer_macro.h"
 #include "zetasql/fuzzing/component/runner.h"
 
+// Defines a fuzzer with input of InputType, extracted by 
+// __VA_ARGS__ of argument extractors, and applied to the fuzz target of TargetType.
 #define ZETASQL_PROTO_FUZZER(InputType, TargetType, ...)            \
   DEFINE_PROTO_FUZZER(const InputType& input) {                     \
     zetasql_fuzzer::Run<InputType, TargetType>(input, __VA_ARGS__); \
   }
 
+// Defines a fuzzer with input interpreted as a string, extracted by 
+// __VA_ARGS__ of argument extractors, and applied to the fuzz target of TargetType.
 #define ZETASQL_SIMPLE_FUZZER(TargetType, ...)                              \
   extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size) { \
     const std::string input(reinterpret_cast<const char*>(Data), Size);     \

--- a/zetasql/fuzzing/oss_fuzz.h
+++ b/zetasql/fuzzing/oss_fuzz.h
@@ -14,8 +14,8 @@
 // limitations under the License.
 //
 
-// Utilities for OSS-Fuzz Initialization
-
+// Deprecated with zetasql_expression_fuzzer. See new implementaiton in 
+// zetasql/fuzzing/component/runner.h Don't use.
 #if defined(__OSS_FUZZ__) && !defined(ZETASQL_FUZZING_OSS_FUZZ_H_)
 #define ZETASQL_FUZZING_OSS_FUZZ_H_
 

--- a/zetasql/fuzzing/protobuf/argument_extractors.h
+++ b/zetasql/fuzzing/protobuf/argument_extractors.h
@@ -23,13 +23,16 @@
 
 namespace zetasql_fuzzer {
 
+// Extracts a pointer to zetasql_fuzzer::SQLStringArg from expression.
 std::unique_ptr<Argument> GetProtoExpr(
     const zetasql_expression_grammar::Expression& expression);
 
+// Extracts a pointer to zetasql_fuzzer::ParameterValueMapArg from expression.
 template <ParameterValueAs Intent>
 extern std::unique_ptr<Argument> GetParam(
     const zetasql_expression_grammar::Expression& expression);
 
+// Extracts a pointer to zetasql_fuzzer::ParameterValueListArg from expression.
 template <ParameterValueAs Intent>
 extern std::unique_ptr<Argument> GetPositionalParam(
     const zetasql_expression_grammar::Expression& expression);

--- a/zetasql/fuzzing/protobuf/internal/literal_value_extractor.h
+++ b/zetasql/fuzzing/protobuf/internal/literal_value_extractor.h
@@ -23,6 +23,8 @@
 namespace zetasql_fuzzer {
 namespace internal {
 
+// Helper methods for converting subtypes of parameter_grammar::Literal
+// to zetasql::Value
 namespace LiteralValueExtractor {
 zetasql::Value Extract(const parameter_grammar::Literal& literal);
 zetasql::Value Extract(const parameter_grammar::IntegerLiteral& integer);

--- a/zetasql/fuzzing/protobuf/internal/parameter_value_list_extractor.h
+++ b/zetasql/fuzzing/protobuf/internal/parameter_value_list_extractor.h
@@ -23,6 +23,9 @@
 namespace zetasql_fuzzer {
 namespace internal {
 
+// Defines a Protobuf encoded SQL syntax tree visitor that sequentially
+// collects all variables of parameter_grammar::Identifier::Type type 
+// in the syntax tree to a zetasql::ParameterValueList
 class ParameterValueListExtractor : public ProtoExprExtractor<zetasql::ParameterValueList> {
  public:
   ParameterValueListExtractor() = delete;

--- a/zetasql/fuzzing/protobuf/internal/parameter_value_map_extractor.h
+++ b/zetasql/fuzzing/protobuf/internal/parameter_value_map_extractor.h
@@ -23,6 +23,9 @@
 namespace zetasql_fuzzer {
 namespace internal {
 
+// Defines a Protobuf encoded SQL syntax tree visitor that collects
+// all variables of parameter_grammar::Identifier::Type type 
+// in the syntax tree to a zetasql::ParameterValueMap
 class ParameterValueMapExtractor : public ProtoExprExtractor<zetasql::ParameterValueMap> {
  public:
   ParameterValueMapExtractor() = delete;

--- a/zetasql/fuzzing/protobuf/internal/syntax_tree_visitor.h
+++ b/zetasql/fuzzing/protobuf/internal/syntax_tree_visitor.h
@@ -20,6 +20,10 @@
 #include "zetasql/fuzzing/protobuf/parameter_grammar.pb.h"
 #include "zetasql/fuzzing/protobuf/zetasql_expression_grammar.pb.h"
 
+// Includes abstract base Visitor class for Protobuf encoded SQL syntax tree.
+// See zetasql_expression_grammar.proto and parameter_grammar.proto for 
+// syntax tree definition.
+
 namespace zetasql_fuzzer {
 namespace internal {
 

--- a/zetasql/fuzzing/protobuf/internal/zetasql_expression_extractor.h
+++ b/zetasql/fuzzing/protobuf/internal/zetasql_expression_extractor.h
@@ -25,6 +25,8 @@
 namespace zetasql_fuzzer {
 namespace internal {
 
+// Defines a Protobuf encoded SQL syntax tree visitor that converts
+// the syntax tree to a SQL expression statement string
 class SQLExprExtractor : public ProtoExprExtractor<std::string>,
                          public LiteralExtractor<std::string> {
  public:
@@ -43,6 +45,7 @@ class SQLExprExtractor : public ProtoExprExtractor<std::string>,
   inline const std::string& Data() override { return builder_; };
 
  protected:
+  // Extract default content of an unset Protobuf one_of struct
   template <typename T>
   inline void ExtractDefault(const T& expr) {
     Append(expr.default_value().content());

--- a/zetasql/fuzzing/protobuf/parameter_grammar.proto
+++ b/zetasql/fuzzing/protobuf/parameter_grammar.proto
@@ -71,7 +71,6 @@ message IntegerLiteral {
     required Default default_value = 5;
 }
 
-// TODO: Support high precision value representation
 message NumericLiteral {
     required bytes value = 1;
 }

--- a/zetasql/fuzzing/protobuf/zetasql_expression_proto_to_string.cc
+++ b/zetasql/fuzzing/protobuf/zetasql_expression_proto_to_string.cc
@@ -20,6 +20,8 @@
 #include "zetasql/fuzzing/protobuf/parameter_grammar.pb.h"
 #include "zetasql/fuzzing/protobuf/zetasql_expression_grammar.pb.h"
 
+// Deprecated with zetasql_expression_fuzzer. Don't use
+
 using zetasql_expression_grammar::Expression;
 using parameter_grammar::Literal;
 using parameter_grammar::IntegerLiteral;

--- a/zetasql/fuzzing/protobuf/zetasql_expression_proto_to_string.h
+++ b/zetasql/fuzzing/protobuf/zetasql_expression_proto_to_string.h
@@ -19,6 +19,8 @@
 
 #include "zetasql/fuzzing/protobuf/zetasql_expression_grammar.pb.h"
 
+// Deprecated with zetasql_expression_fuzzer. Don't use
+
 using zetasql_expression_grammar::Expression;
 
 namespace zetasql_fuzzer {

--- a/zetasql/fuzzing/simple_evaluator_fuzzer.cc
+++ b/zetasql/fuzzing/simple_evaluator_fuzzer.cc
@@ -23,7 +23,5 @@
 using zetasql_fuzzer::PreparedExpressionTarget;
 using zetasql_fuzzer::SQLStringArg;
 
-// This functions interprets raw fuzzing input as a SQL string, which will be
-// applied to PreparedExpressionTarget
 ZETASQL_SIMPLE_FUZZER(PreparedExpressionTarget,
                       std::make_unique<SQLStringArg, const std::string&>);

--- a/zetasql/fuzzing/zetasql_expression_fuzzer.cc
+++ b/zetasql/fuzzing/zetasql_expression_fuzzer.cc
@@ -22,6 +22,7 @@
 
 using zetasql_expression_grammar::Expression;
 
+// Deprecated by pipelined_expression_fuzzer. Don't use.
 DEFINE_PROTO_FUZZER(const Expression& expression) {
     #ifdef __OSS_FUZZ__
       static bool Initialized = zetasql_fuzzer::DoOssFuzzInit();


### PR DESCRIPTION
This PR updates `/README.md` and `/zetasql/fuzzing/README.md` for documentations. The link in `/README.md` is intentionally set to `master` branch since it'll be eventually merged to master